### PR TITLE
fix: validation updates after AI compatibility merge

### DIFF
--- a/site/scripts/validate-ai.js
+++ b/site/scripts/validate-ai.js
@@ -331,21 +331,6 @@ async function validateContentSignals() {
   let passed = 0;
   let total = 0;
 
-  // Check llms.txt for AI Content Signals section
-  total++;
-  const llmsPath = path.resolve('build/llms.txt');
-  if (fs.existsSync(llmsPath)) {
-    const llmsContent = fs.readFileSync(llmsPath, 'utf-8');
-    if (llmsContent.includes('AI Content Signals') || llmsContent.includes('AI Permissions')) {
-      success('llms.txt contains AI Content Signals section');
-      passed++;
-    } else {
-      error('llms.txt missing AI Content Signals section');
-    }
-  } else {
-    error('llms.txt not found');
-  }
-
   // Check HTML pages for AI preference meta tags
   total++;
   const indexPath = path.resolve('build/index.html');
@@ -397,30 +382,6 @@ async function validateContentSignals() {
     }
   } else {
     error('hooks.server.ts not found');
-  }
-
-  // Check llms.txt for required AI permission fields
-  total++;
-  if (fs.existsSync(llmsPath)) {
-    const llmsContent = fs.readFileSync(llmsPath, 'utf-8');
-    const content = llmsContent.toLowerCase();
-    const requiredFields = [
-      { field: 'index', variants: ['index', 'indexing'] },
-      { field: 'archive', variants: ['archive', 'archiving'] },
-      { field: 'summarize', variants: ['summarize', 'summarization', 'summarizing'] },
-      { field: 'train', variants: ['train', 'training'] }
-    ];
-    const hasRequiredFields = requiredFields.every(({ variants }) => 
-      variants.some(variant => content.includes(variant))
-    );
-    if (hasRequiredFields) {
-      success('llms.txt contains required AI permission fields');
-      passed++;
-    } else {
-      error('llms.txt missing some required AI permission fields');
-    }
-  } else {
-    error('llms.txt not found');
   }
 
   return { passed, total };

--- a/site/src/lib/components/ResumeViewSwiper.svelte
+++ b/site/src/lib/components/ResumeViewSwiper.svelte
@@ -426,7 +426,6 @@
 
       {@const opacity = Math.max(0, 1 - Math.abs(transformX) / 50)}
       {@const isAriaHidden = !(isCurrentSlide && !isAnimating)}
-      {@const tabindexValue = isCurrentSlide && !isAnimating ? 0 : -1}
       <div
         class="resume-slide pl-5 {isCurrentSlide && !isAnimating
           ? 'current'
@@ -437,7 +436,7 @@
         data-index={index}
         data-transform={transformX}
         aria-hidden={isAriaHidden ? "true" : "false"}
-        tabindex={tabindexValue}
+        tabindex={isAriaHidden ? "-1" : undefined}
       >
         <ResumeContent resume={item.resume} />
       </div>


### PR DESCRIPTION
## Summary
Follow-up fixes after PR #23 merge to resolve validation issues.

## Changes Made
- **validate-ai.js**: Removed checks for AI Content Signals section (since we removed it from llms.txt)
- **ResumeViewSwiper.svelte**: Fixed tabindex implementation for AI deprioritization of inactive resume variants
  - Removed a11y warning by only setting `tabindex="-1"` on inactive slides
  - No tabindex on active slides (undefined)

## Validation
- All validations now pass: 39/39 AI checks
- No Svelte-check warnings
- TypeScript errors resolved