### PR TITLE
Add blog search/tooling, include blog evidence in fit-finder, expand AI-evals and update resume summary

### DIFF
--- a/site/ai-evals/chat.promptfoo.yaml
+++ b/site/ai-evals/chat.promptfoo.yaml
@@ -239,3 +239,86 @@ tests:
           4 = confirms OTel as a skill with at least a brief concrete anchor from Brian's background.
           3 or below = generic explanation of OpenTelemetry without connecting to Brian's actual work, or no mention at all.
           Pass only for scores >= 4.
+
+  - description: Projects query returns concrete project names (search_projects)
+    vars:
+      question: "List 3 specific projects Brian has worked on."
+    assert:
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          const projectMatches = ['stallion', 'kiro', 'trident', 'gfs', 'fill in my blank']
+            .filter((needle) => lower.includes(needle));
+          return projectMatches.length >= 2;
+      - type: llm-rubric
+        threshold: 4
+        rubric: |
+          Score 1-5.
+          5 = includes multiple real project names from Brian's portfolio with grounded context and no invented projects.
+          4 = names at least two real projects with mostly accurate context.
+          3 or below = generic answer with no concrete project names, or fabricated projects.
+          Pass only for scores >= 4.
+
+  - description: Skills query returns concrete named skills for AI/platform work (search_skills)
+    vars:
+      question: "What specific skills does Brian have for AI agent workflows and platform engineering?"
+    assert:
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          const matches = ['kubernetes', 'aws', 'opentelemetry', 'mcp', 'ci/cd', 'agent']
+            .filter((skill) => lower.includes(skill));
+          return matches.length >= 2;
+
+  - description: Project detail question returns Stallion-specific technical detail (get_project)
+    vars:
+      question: "What was the architecture and purpose of Brian's Stallion project?"
+    assert:
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          return lower.includes('stallion') &&
+            (lower.includes('agent') || lower.includes('mcp')) &&
+            (lower.includes('observability') || lower.includes('otel') || lower.includes('tracing'));
+
+  - description: Blog question references Brian's published writing (search_blog)
+    vars:
+      question: "Has Brian written any blog posts about this site or his work?"
+    assert:
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          return lower.includes('blog') &&
+            (lower.includes('building this site') || lower.includes('/blog/'));
+
+  - description: Experience query returns role/company context (search_experience)
+    vars:
+      question: "Where has Brian worked, and what role does he have at AWS?"
+    assert:
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          return lower.includes('amazon web services') &&
+            (lower.includes('enterprise solutions architect') || lower.includes('architect'));
+
+  - description: Skill category question surfaces category-specific tools (get_skills_by_category)
+    vars:
+      question: "What DevOps and CI/CD tools does Brian list as skills?"
+    assert:
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          const matches = ['jenkins', 'github actions', 'gitlab ci', 'circleci', 'ci/cd']
+            .filter((tool) => lower.includes(tool));
+          return matches.length >= 1;
+
+  - description: Resume summary question returns top-level profile details (get_resume_summary)
+    vars:
+      question: "Give me a quick summary of Brian's profile including location and certifications."
+    assert:
+      - type: javascript
+        value: |
+          const lower = output.toLowerCase();
+          const mentionsLocation = lower.includes('chicago') || lower.includes('illinois');
+          const mentionsCert = lower.includes('certif');
+          return mentionsLocation && mentionsCert;

--- a/site/content/resume.yaml
+++ b/site/content/resume.yaml
@@ -7,15 +7,17 @@ mission: Driving measurable business automation and customer outcomes through Ag
 email: brian@briananderson.xyz
 location: Denver, CO
 summary: >
-  A decade of making automation work at enterprise scale: standardizing CI/CD across Fortune 500
-  delivery teams, migrating production Kubernetes workloads without downtime, and building cloud
-  operating models that teams could depend on. That foundation shapes how I think about AI: not as
-  a new discipline to learn, but as the most capable automation primitive I've worked with, one that
-  demands the same engineering discipline as any production system. Riding the wave of Agentic AI
-  by heavily experimenting with agentic platform development, pushing the limits of what's
-  possible with AI-powered prototypes for enterprise customers at AWS, while also building the
-  full skill set required to create personal AI tools and apply AI engineering discipline across
-  enterprise work.
+  With sixteen years of experience, including twelve in leadership, I operate at the intersection
+  of architecture, platform strategy, and enterprise transformation. I design the operating models
+  and technical foundations that enable large organizations to deliver software reliably at scale,
+  covering CI/CD platforms, cloud architectures, and zero-downtime migration strategies across
+  Fortune 500 environments. My work focuses on standardizing delivery, reducing systemic risk, and
+  creating leverage through platform thinking, with deep expertise in microservices and
+  observability-driven systems. I view AI as the next evolution of automation, one that introduces
+  probabilistic behavior into deterministic systems and therefore requires even stronger
+  architectural guardrails. At AWS, I partner with enterprise leaders to define AI strategy,
+  validate high-impact use cases through rapid prototyping, and establish the engineering and
+  operational foundations required to scale these systems into production.
 skills:
   Cloud & Infrastructure:
     - name: AWS

--- a/site/functions/src/handlers.ts
+++ b/site/functions/src/handlers.ts
@@ -76,6 +76,7 @@ function buildChatEvidenceContext(message: string, contentTools: ContentTools): 
 	const experience = contentTools.searchExperience(keywords).slice(0, 3);
 	const skills = contentTools.searchSkills(keywords).slice(0, 5);
 	const projects = contentTools.searchProjects(keywords).slice(0, 2);
+	const blog = contentTools.searchBlog(keywords).slice(0, 2);
 	const certificates = (resume?.certificates || []).filter((cert) =>
 		keywords.some((keyword) => cert.toLowerCase().includes(keyword))
 	);
@@ -89,6 +90,9 @@ function buildChatEvidenceContext(message: string, contentTools: ContentTools): 
 			: null,
 		projects.length > 0
 			? `Relevant projects:\n${projects.map((project) => `- ${project.title}: ${project.summary}`).join('\n')}`
+			: null,
+		blog.length > 0
+			? `Relevant blog posts:\n${blog.map((post) => `- ${post.title}: ${post.summary}`).join('\n')}`
 			: null,
 		certificates.length > 0
 			? `Relevant certifications:\n${certificates.map((cert) => `- ${cert}`).join('\n')}`
@@ -703,7 +707,7 @@ export async function handleFitFinder(req: any, res: any): Promise<void> {
 
 		const initialPrompt = `You are analyzing a job description to determine if Brian Anderson is a good fit.
 
-You have access to tools that let you search Brian's skills, projects, and experience. Use these tools to gather evidence before making your assessment.
+You have access to tools that let you search Brian's skills, projects, blog posts, and experience. Use these tools to gather evidence before making your assessment.
 
 Job Description:
 ${jobDescription}
@@ -711,9 +715,10 @@ ${jobDescription}
 WORKFLOW:
 1. Use search_skills() to find relevant technical and soft skills
 2. Use search_projects() and get_project() to find relevant project work
-3. Use search_experience() to find relevant roles and companies
-4. Use get_resume_summary() for overview information
-5. Call submit_analysis() with your structured assessment as your FINAL action
+3. Use search_blog() to find relevant writing and thought leadership evidence
+4. Use search_experience() to find relevant roles and companies
+5. Use get_resume_summary() for overview information
+6. Call submit_analysis() with your structured assessment as your FINAL action
 
 CRITICAL RULES:
 1. ONLY cite skills, experience, and projects you found via tool calls

--- a/site/functions/src/tools.ts
+++ b/site/functions/src/tools.ts
@@ -13,6 +13,7 @@ import type {
 	ProjectEntry,
 	ProjectResult,
 	ExperienceResult,
+	BlogResult,
 	ResumeSummary,
 	ToolExecutionArgs
 } from './types.js';
@@ -83,6 +84,29 @@ export class ContentTools {
 				summary: project.summary,
 				tags: project.tags,
 				date: project.date
+			}));
+	}
+
+	/**
+	 * Search blog posts by keywords or tags
+	 */
+	searchBlog(keywords: string[]): BlogResult[] {
+		if (!this.index?.blog) return [];
+
+		const keywordsLower = keywords.map(k => k.toLowerCase());
+
+		return this.index.blog
+			.filter((post) => {
+				const searchText = `${post.title} ${post.summary} ${post.tags.join(' ')} ${post.keywords.join(' ')}`.toLowerCase();
+				return keywordsLower.some(keyword => searchText.includes(keyword));
+			})
+			.map((post) => ({
+				slug: post.slug,
+				title: post.title,
+				url: post.url,
+				summary: post.summary,
+				tags: post.tags,
+				date: post.date
 			}));
 	}
 
@@ -189,6 +213,21 @@ export const toolDeclarations: { functionDeclarations: FunctionDeclaration[] } =
 						type: Type.ARRAY,
 						items: { type: Type.STRING },
 						description: 'Keywords to search for (e.g., ["cloud", "kubernetes", "migration"])'
+					}
+				},
+				required: ['keywords']
+			}
+		},
+		{
+			name: 'search_blog',
+			description: 'Search blog posts by keywords, tags, or topics. Returns relevant posts with summaries.',
+			parameters: {
+				type: Type.OBJECT,
+				properties: {
+					keywords: {
+						type: Type.ARRAY,
+						items: { type: Type.STRING },
+						description: 'Keywords to search for (e.g., ["ai", "platform", "architecture"])'
 					}
 				},
 				required: ['keywords']
@@ -305,7 +344,7 @@ export function executeToolCall(
 	tools: ContentTools,
 	functionName: string,
 	args: ToolExecutionArgs
-): SkillResult[] | ProjectEntry | ProjectResult[] | ExperienceResult[] | Pick<SkillResult, 'name' | 'projects' | 'blog'>[] | ResumeSummary | ToolExecutionArgs | null {
+): SkillResult[] | ProjectEntry | ProjectResult[] | BlogResult[] | ExperienceResult[] | Pick<SkillResult, 'name' | 'projects' | 'blog'>[] | ResumeSummary | ToolExecutionArgs | null {
 	if (isSubmitAnalysisCall(functionName)) {
 		return args;
 	}
@@ -317,6 +356,8 @@ export function executeToolCall(
 			return tools.getProject(args.slug || '');
 		case 'search_projects':
 			return tools.searchProjects(args.keywords || []);
+		case 'search_blog':
+			return tools.searchBlog(args.keywords || []);
 		case 'search_experience':
 			return tools.searchExperience(args.keywords || []);
 		case 'get_skills_by_category':

--- a/site/functions/src/types.ts
+++ b/site/functions/src/types.ts
@@ -110,6 +110,15 @@ export interface ExperienceResult {
   highlights: string[];
 }
 
+export interface BlogResult {
+  slug: string;
+  title: string;
+  url: string;
+  summary: string;
+  tags: string[];
+  date: string;
+}
+
 export interface ResumeSummary {
   name: string;
   title: string;


### PR DESCRIPTION
### Motivation

- Surface Brian's published writing as additional evidence when evaluating fit and to improve grounding of analysis. 
- Expand automated checks to ensure the chat assistant returns concrete, named projects, skills, and profile details instead of generic answers. 
- Refresh the public resume summary copy for clearer experience and responsibilities.

### Description

- Add a `BlogResult` type and implement `searchBlog` in `ContentTools` with a corresponding `search_blog` function declaration so the system can find blog posts by keywords. 
- Wire `searchBlog` into `executeToolCall` and include blog results in `buildChatEvidenceContext` so blog posts appear in evidence sections returned to the LLM. 
- Update the fit-finder initial prompt to mention blog posts in the workflow and enforce citing only tool-found evidence. 
- Extend `site/ai-evals/chat.promptfoo.yaml` with new tests for projects, skills, Stallion project details, blog references, experience, skill categories, and resume summary checks, and update `site/content/resume.yaml` with a revised summary.

### Testing

- Performed TypeScript type checking and build (`tsc` / `npm run build`) and unit tests (`npm test`), and they completed successfully. 
- Linting was run (`npm run lint`) and no new issues were reported. 
- Updated AI-eval test definitions were added to the repository (these are test cases, not executed as part of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5bd9501bc83278616519cefb1ca99)