### PR TITLE
Wave 1: security + SEO + deploy-reliability fixes from site audit

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Build functions
         working-directory: site/functions
         run: pnpm run build
+      - name: Test functions
+        working-directory: site/functions
+        run: pnpm test
       - uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
@@ -395,6 +398,7 @@ jobs:
         working-directory: site
         env:
           AI_EVAL_BASE_URL: https://api-dev.briananderson.xyz
+          AI_EVAL_MIN_PASS_RATE: "0.95"
         continue-on-error: true
         run: pnpm run test:ai:evals
       - name: Upload dev build artifact (Verified)
@@ -420,7 +424,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           echo "❌ Smoke tests failed, rolling back dev to run $LAST_RUN_ID..."
-          gh run download $LAST_RUN_ID -n build-artifact-dev
+          rm -rf site/build && gh run download $LAST_RUN_ID -n build-artifact-dev --dir site/build/
 
           # Upload with proper cache headers
           gcloud storage rsync site/build/_app gs://dev.briananderson.xyz/_app --recursive --cache-control="public, max-age=31536000, immutable"
@@ -571,7 +575,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           echo "❌ Smoke tests failed, rolling back prod to run $LAST_RUN_ID..."
-          gh run download $LAST_RUN_ID -n build-artifact-prod
+          rm -rf site/build && gh run download $LAST_RUN_ID -n build-artifact-prod --dir site/build/
 
           # Upload with proper cache headers
           gcloud storage rsync site/build/_app gs://briananderson.xyz/_app --recursive --cache-control="public, max-age=31536000, immutable"

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ site/static/content-index*.json
 # Windows artifacts
 nul
 site/package-lock.json
+
+# Flow Agents runtime workflow artifacts (local scratch)
+.kontourai/

--- a/site/functions/package.json
+++ b/site/functions/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "node --env-file-if-exists=.env.local lib/server.js",
-    "dev:fitfinder": "FUNCTION_TARGET=fitfinder node --env-file-if-exists=.env.local lib/server.js"
+    "dev:fitfinder": "FUNCTION_TARGET=fitfinder node --env-file-if-exists=.env.local lib/server.js",
+    "test": "pnpm run build && node --test lib/**/*.test.js"
   },
   "engines": {
     "node": "22"
@@ -12,7 +13,8 @@
   "main": "lib/server.js",
   "dependencies": {
     "@google/genai": "^1.0.0",
-    "express": "^4.21.0"
+    "express": "^4.21.0",
+    "express-rate-limit": "^8.5.2"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/site/functions/pnpm-lock.yaml
+++ b/site/functions/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       express:
         specifier: ^4.21.0
         version: 4.22.1
+      express-rate-limit:
+        specifier: ^8.5.2
+        version: 8.5.2(express@4.22.1)
     devDependencies:
       '@types/express':
         specifier: ^5.0.0
@@ -259,6 +262,12 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
   express@4.22.1:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
@@ -352,6 +361,10 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -825,6 +838,11 @@ snapshots:
 
   etag@1.8.1: {}
 
+  express-rate-limit@8.5.2(express@4.22.1):
+    dependencies:
+      express: 4.22.1
+      ip-address: 10.2.0
+
   express@4.22.1:
     dependencies:
       accepts: 1.3.8
@@ -988,6 +1006,8 @@ snapshots:
       safer-buffer: 2.1.2
 
   inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 

--- a/site/functions/src/handlers.ts
+++ b/site/functions/src/handlers.ts
@@ -18,6 +18,15 @@ import type {
 	ChatRequest,
 	FitFinderRequest
 } from './types.js';
+import {
+	corsHeadersFor,
+	isAllowedCtaLink,
+	validateHistory,
+	MAX_MESSAGE_BYTES,
+	MAX_JOBDESC_BYTES,
+	isValidVariant,
+	type Variant
+} from './security.js';
 
 const IS_PRODUCTION = process.env.NODE_ENV === 'production';
 const SITE_URL =
@@ -428,7 +437,8 @@ function stabilizeFitAnalysis(
 			candidate.cta &&
 			typeof candidate.cta === 'object' &&
 			typeof (candidate.cta as { text?: string }).text === 'string' &&
-			typeof (candidate.cta as { link?: string }).link === 'string'
+			typeof (candidate.cta as { link?: string }).link === 'string' &&
+			isAllowedCtaLink((candidate.cta as { link: string }).link)
 				? candidate.cta
 				: fallback.cta
 	};
@@ -514,13 +524,6 @@ async function fetchContentIndexInner(): Promise<ContentIndex | null> {
 	}
 }
 
-// CORS headers
-const corsHeaders = {
-	'Access-Control-Allow-Origin': '*',
-	'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-	'Access-Control-Allow-Headers': 'Content-Type',
-};
-
 /**
  * Chat handler — can be called from Firebase Functions or Express/Cloud Run
  */
@@ -528,7 +531,7 @@ const corsHeaders = {
 export async function handleChat(req: any, res: any): Promise<void> {
 	// Handle preflight
 	if (req.method === 'OPTIONS') {
-		res.set(corsHeaders);
+		res.set(corsHeadersFor(req));
 		res.status(204).send('');
 		return;
 	}
@@ -539,22 +542,52 @@ export async function handleChat(req: any, res: any): Promise<void> {
 	}
 
 	try {
-		const { message, history = [] }: ChatRequest = req.body;
+		const { message, history = [], variant: rawVariant }: ChatRequest = req.body;
+
+		// SEC-2: variant is only a TypeScript-compile-time constraint; validate
+		// it at runtime too, before it can reach any downstream prompt use.
+		if (rawVariant !== undefined && !isValidVariant(rawVariant)) {
+			res.status(400).json({ error: 'Invalid variant' });
+			return;
+		}
 
 		if (!message || typeof message !== 'string') {
 			res.status(400).json({ error: 'Message is required' });
 			return;
 		}
 
+		if (Buffer.byteLength(message, 'utf8') > MAX_MESSAGE_BYTES) {
+			res.status(400).json({ error: 'Message exceeds maximum allowed size' });
+			return;
+		}
+
+		const historyCheck = validateHistory(history);
+		if (!historyCheck.ok) {
+			res.status(400).json({ error: historyCheck.error || 'Invalid history' });
+			return;
+		}
+
 		// Check guardrails
 		const guardrailCheck = checkGuardrails(message);
 		if (!guardrailCheck.allowed) {
-			res.set(corsHeaders);
+			res.set(corsHeadersFor(req));
 			res.status(200).json({
 				response: getRefusalMessage(guardrailCheck.reason || 'unknown'),
 				blocked: true
 			});
 			return;
+		}
+
+		for (const entry of history) {
+			const historyGuardrailCheck = checkGuardrails(entry.content);
+			if (!historyGuardrailCheck.allowed) {
+				res.set(corsHeadersFor(req));
+				res.status(200).json({
+					response: getRefusalMessage(historyGuardrailCheck.reason || 'unknown'),
+					blocked: true
+				});
+				return;
+			}
 		}
 
 		// Require Gemini API key
@@ -573,7 +606,12 @@ export async function handleChat(req: any, res: any): Promise<void> {
 
 		const ai = new GoogleGenAI({ apiKey: GEMINI_API_KEY });
 
-		// Convert history to Gemini format
+		// Convert history to Gemini format. SEC-3 (accepted residual, this wave):
+		// history is entirely client-supplied with no server-side session
+		// binding, so a `role: 'model'` entry only proves shape/size validity
+		// (validateHistory) and passing guardrails, not that the assistant
+		// actually said it; session binding + combined-text semantic guardrails
+		// are out of scope for this wave.
 		const chatHistory = history.map((msg) => ({
 			role: msg.role === 'user' ? ('user' as const) : ('model' as const),
 			parts: [{ text: msg.content }],
@@ -601,7 +639,7 @@ export async function handleChat(req: any, res: any): Promise<void> {
 
 		const deterministicResponse = buildDeterministicChatResponse(message, contentTools);
 		if (deterministicResponse) {
-			res.set(corsHeaders);
+			res.set(corsHeadersFor(req));
 			res.status(200).json({
 				response: deterministicResponse
 			});
@@ -639,7 +677,7 @@ export async function handleChat(req: any, res: any): Promise<void> {
 
 		const response = normalizeChatResponse(message, result.text || '', contentTools);
 
-		res.set(corsHeaders);
+		res.set(corsHeadersFor(req));
 		res.status(200).json({
 			response
 		});
@@ -657,7 +695,7 @@ export async function handleChat(req: any, res: any): Promise<void> {
 export async function handleFitFinder(req: any, res: any): Promise<void> {
 	// Handle preflight
 	if (req.method === 'OPTIONS') {
-		res.set(corsHeaders);
+		res.set(corsHeadersFor(req));
 		res.status(204).send('');
 		return;
 	}
@@ -668,10 +706,33 @@ export async function handleFitFinder(req: any, res: any): Promise<void> {
 	}
 
 	try {
-		const { jobDescription, variant = 'leader' }: FitFinderRequest = req.body;
+		const { jobDescription, variant: rawVariant }: FitFinderRequest = req.body;
+
+		// SEC-2: variant is interpolated directly into the fit-finder prompt
+		// below — validate against the real enum at runtime rather than
+		// trusting the (compile-time-only) FitFinderRequest type. Reject an
+		// explicitly-supplied invalid value instead of silently coercing it.
+		if (rawVariant !== undefined && !isValidVariant(rawVariant)) {
+			res.status(400).json({ error: 'Invalid variant' });
+			return;
+		}
+		const variant: Variant = isValidVariant(rawVariant) ? rawVariant : 'leader';
 
 		if (!jobDescription || typeof jobDescription !== 'string') {
 			res.status(400).json({ error: 'Job description is required' });
+			return;
+		}
+
+		if (Buffer.byteLength(jobDescription, 'utf8') > MAX_JOBDESC_BYTES) {
+			res.status(400).json({ error: 'Job description exceeds maximum allowed size' });
+			return;
+		}
+
+		const jobDescriptionGuardrailCheck = checkGuardrails(jobDescription);
+		if (!jobDescriptionGuardrailCheck.allowed) {
+			res.status(400).json({
+				error: getRefusalMessage(jobDescriptionGuardrailCheck.reason || 'unknown')
+			});
 			return;
 		}
 
@@ -851,7 +912,7 @@ FIT LEVELS:
 			analysis = stabilizeFitAnalysis(analysis, fallbackAnalysis);
 			analysis = normalizeFitAnalysis(jobDescription, analysis);
 
-			res.set(corsHeaders);
+			res.set(corsHeadersFor(req));
 			res.status(200).json({
 				analysis
 			});
@@ -862,4 +923,19 @@ FIT LEVELS:
 	}
 }
 
-export { corsHeaders };
+// Backward-compatible re-exports for any importer/tests that previously
+// pulled these symbols from handlers.ts (they now live in security.ts).
+export {
+	ALLOWED_ORIGINS,
+	PRIMARY_ORIGIN,
+	corsHeaders,
+	corsHeadersFor,
+	isAllowedCtaLink,
+	validateHistory,
+	MAX_MESSAGE_BYTES,
+	MAX_JOBDESC_BYTES,
+	MAX_HISTORY,
+	MAX_HISTORY_CONTENT_BYTES,
+	ALLOWED_VARIANTS,
+	isValidVariant
+} from './security.js';

--- a/site/functions/src/security.test.ts
+++ b/site/functions/src/security.test.ts
@@ -1,0 +1,190 @@
+/**
+ * node:test coverage for site/functions/src/security.ts.
+ * Run via `pnpm test` (builds with tsc, then `node --test` against the
+ * compiled lib/ output — see package.json).
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	ALLOWED_ORIGINS,
+	PRIMARY_ORIGIN,
+	corsHeadersFor,
+	corsHeaders,
+	isAllowedCtaLink,
+	validateHistory,
+	MAX_HISTORY,
+	MAX_HISTORY_CONTENT_BYTES,
+	ALLOWED_VARIANTS,
+	isValidVariant
+} from './security.js';
+
+describe('isAllowedCtaLink — AC-11 bypass vectors', () => {
+	const vectors: Array<[string, boolean]> = [
+		['/\\evil.com', false],
+		['/\\/evil.com', false],
+		['/..//evil.com', true],
+		[' javascript:alert(1)', false],
+		['https:/\\evil.com', false],
+		['/contact/', true],
+		['https://x.com', true],
+		['MAILTO:A@B.com', true]
+	];
+
+	for (const [input, expected] of vectors) {
+		test(`isAllowedCtaLink(${JSON.stringify(input)}) === ${expected}`, () => {
+			assert.equal(isAllowedCtaLink(input), expected);
+		});
+	}
+
+	test('rejects the raw open-redirect bypass primitive', () => {
+		// Confirms the underlying browser/URL-normalization trick is real...
+		assert.equal(new URL('/\\evil.com', 'https://briananderson.xyz').href, 'https://evil.com/');
+		// ...and that isAllowedCtaLink is not fooled by it.
+		assert.equal(isAllowedCtaLink('/\\evil.com'), false);
+	});
+
+	test('rejects protocol-relative //', () => {
+		assert.equal(isAllowedCtaLink('//evil.com'), false);
+	});
+
+	test('rejects javascript:/data:/http:/vbscript: schemes', () => {
+		assert.equal(isAllowedCtaLink('javascript:alert(1)'), false);
+		assert.equal(isAllowedCtaLink('data:text/html,x'), false);
+		assert.equal(isAllowedCtaLink('http://x.com'), false);
+		assert.equal(isAllowedCtaLink('vbscript:msgbox(1)'), false);
+	});
+
+	test('rejects non-string / empty input', () => {
+		// @ts-expect-error - intentionally testing runtime guard against bad input
+		assert.equal(isAllowedCtaLink(undefined), false);
+		assert.equal(isAllowedCtaLink(''), false);
+	});
+
+	test('accepts mailto: case-insensitively', () => {
+		assert.equal(isAllowedCtaLink('mailto:a@b.com'), true);
+	});
+});
+
+describe('validateHistory', () => {
+	test('accepts a valid history array', () => {
+		const result = validateHistory([
+			{ role: 'user', content: 'hi' },
+			{ role: 'assistant', content: 'hello' },
+			{ role: 'model', content: 'hi there' }
+		]);
+		assert.deepEqual(result, { ok: true });
+	});
+
+	test('accepts an empty array', () => {
+		assert.deepEqual(validateHistory([]), { ok: true });
+	});
+
+	test('rejects a non-array', () => {
+		const result = validateHistory('not-an-array');
+		assert.equal(result.ok, false);
+		assert.equal(result.error, 'History must be an array');
+	});
+
+	test(`rejects more than ${MAX_HISTORY} entries`, () => {
+		const history = Array.from({ length: MAX_HISTORY + 1 }, () => ({ role: 'user', content: 'x' }));
+		const result = validateHistory(history);
+		assert.equal(result.ok, false);
+		assert.match(result.error ?? '', new RegExp(`${MAX_HISTORY} entries`));
+	});
+
+	test('accepts exactly the max entry count', () => {
+		const history = Array.from({ length: MAX_HISTORY }, () => ({ role: 'user', content: 'x' }));
+		assert.equal(validateHistory(history).ok, true);
+	});
+
+	test('rejects an invalid role, including client-local "system"', () => {
+		const result = validateHistory([{ role: 'system', content: 'Sorry, an error occurred.' }]);
+		assert.equal(result.ok, false);
+		assert.equal(result.error, 'Invalid history entry role');
+	});
+
+	test('rejects a non-string content field', () => {
+		const result = validateHistory([{ role: 'user', content: 42 }]);
+		assert.equal(result.ok, false);
+		assert.equal(result.error, 'Invalid history entry content');
+	});
+
+	test('rejects oversized entry content', () => {
+		const oversized = 'a'.repeat(MAX_HISTORY_CONTENT_BYTES + 1);
+		const result = validateHistory([{ role: 'user', content: oversized }]);
+		assert.equal(result.ok, false);
+		assert.match(result.error ?? '', /must not exceed/);
+	});
+
+	test('accepts content at exactly the byte cap', () => {
+		const atCap = 'a'.repeat(MAX_HISTORY_CONTENT_BYTES);
+		assert.equal(validateHistory([{ role: 'user', content: atCap }]).ok, true);
+	});
+
+	test('rejects a non-object entry', () => {
+		assert.equal(validateHistory([null]).ok, false);
+		assert.equal(validateHistory(['a string entry']).ok, false);
+	});
+});
+
+describe('corsHeadersFor', () => {
+	test('echoes an allowlisted Origin', () => {
+		for (const origin of ALLOWED_ORIGINS) {
+			const headers = corsHeadersFor({ headers: { origin } });
+			assert.equal(headers['Access-Control-Allow-Origin'], origin);
+		}
+	});
+
+	test('falls back to the primary origin for a non-allowlisted Origin', () => {
+		const headers = corsHeadersFor({ headers: { origin: 'https://evil.com' } });
+		assert.equal(headers['Access-Control-Allow-Origin'], PRIMARY_ORIGIN);
+	});
+
+	test('falls back to the primary origin when Origin is missing', () => {
+		const headers = corsHeadersFor({ headers: {} });
+		assert.equal(headers['Access-Control-Allow-Origin'], PRIMARY_ORIGIN);
+	});
+
+	test('falls back to the primary origin when Origin is an array (malformed request)', () => {
+		const headers = corsHeadersFor({ headers: { origin: ['https://briananderson.xyz', 'https://evil.com'] } });
+		assert.equal(headers['Access-Control-Allow-Origin'], PRIMARY_ORIGIN);
+	});
+
+	test('always sets Vary: Origin', () => {
+		assert.equal(corsHeadersFor({ headers: {} })['Vary'], 'Origin');
+		assert.equal(corsHeadersFor({ headers: { origin: PRIMARY_ORIGIN } })['Vary'], 'Origin');
+	});
+
+	test('sets Methods/Headers', () => {
+		const headers = corsHeadersFor({ headers: {} });
+		assert.equal(headers['Access-Control-Allow-Methods'], 'GET, POST, OPTIONS');
+		assert.equal(headers['Access-Control-Allow-Headers'], 'Content-Type');
+	});
+
+	test('backward-compatible static corsHeaders export defaults to the primary origin', () => {
+		assert.equal(corsHeaders['Access-Control-Allow-Origin'], PRIMARY_ORIGIN);
+	});
+});
+
+describe('isValidVariant — AC-16', () => {
+	test('accepts every value in ALLOWED_VARIANTS', () => {
+		for (const variant of ALLOWED_VARIANTS) {
+			assert.equal(isValidVariant(variant), true);
+		}
+	});
+
+	test('rejects an unknown variant string', () => {
+		assert.equal(isValidVariant('default'), false);
+		assert.equal(isValidVariant('admin'), false);
+	});
+
+	test('rejects non-string / undefined variant', () => {
+		assert.equal(isValidVariant(undefined), false);
+		assert.equal(isValidVariant(42), false);
+		assert.equal(isValidVariant(null), false);
+	});
+
+	test('is case-sensitive (does not silently normalize)', () => {
+		assert.equal(isValidVariant('Leader'), false);
+	});
+});

--- a/site/functions/src/security.ts
+++ b/site/functions/src/security.ts
@@ -1,0 +1,174 @@
+/**
+ * Security-related pure helpers shared by the Express server (`server.ts`)
+ * and the request handlers (`handlers.ts`): CORS allowlist headers, CTA link
+ * scheme/origin whitelisting, chat history validation, input size caps, and
+ * fit-finder `variant` validation. Kept dependency-free and side-effect-free
+ * (module load time excepted) so it can be unit tested directly with
+ * `node:test` — see `security.test.ts`.
+ */
+
+// ---------------------------------------------------------------------------
+// CORS allowlist
+// ---------------------------------------------------------------------------
+
+export const ALLOWED_ORIGINS = [
+	'https://briananderson.xyz',
+	'https://www.briananderson.xyz',
+	'http://localhost:5173'
+];
+export const PRIMARY_ORIGIN = 'https://briananderson.xyz';
+
+/**
+ * Origin-aware CORS headers: echoes the request Origin when it is on the
+ * allowlist, otherwise falls back to the primary origin. Always varies on
+ * Origin so caches don't leak one origin's headers to another.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function corsHeadersFor(req: any): Record<string, string> {
+	const requestOrigin = req?.headers?.origin;
+	const allowOrigin =
+		typeof requestOrigin === 'string' && ALLOWED_ORIGINS.includes(requestOrigin)
+			? requestOrigin
+			: PRIMARY_ORIGIN;
+
+	return {
+		'Access-Control-Allow-Origin': allowOrigin,
+		'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+		'Access-Control-Allow-Headers': 'Content-Type',
+		'Vary': 'Origin',
+	};
+}
+
+// Backward-compatible static export (primary-origin headers) for any external importer
+export const corsHeaders = corsHeadersFor({ headers: {} });
+
+// ---------------------------------------------------------------------------
+// CTA link whitelist
+// ---------------------------------------------------------------------------
+
+/**
+ * Whitelists CTA link schemes/targets before a model-controlled link reaches
+ * the client. Rejects:
+ *  - any embedded backslash (spec-compliant URL parsers — and browsers —
+ *    normalize `\` to `/` for special schemes, which is how a "relative"
+ *    link like `/\evil.com` actually resolves to `https://evil.com/`)
+ *  - ASCII control characters, or leading/trailing whitespace (e.g. a
+ *    leading space before `javascript:` that some parsers tolerate)
+ *  - protocol-relative `//` links
+ * Relative paths (starting with a single `/`) must resolve, against
+ * PRIMARY_ORIGIN, to that same origin. Absolute URLs must use the `https:`
+ * or `mailto:` scheme (case-insensitive; `new URL().protocol` is always
+ * lowercased). Any parse failure is treated as not-allowed. Pure function —
+ * safe to unit test directly.
+ */
+export function isAllowedCtaLink(link: string): boolean {
+	if (typeof link !== 'string' || link.length === 0) {
+		return false;
+	}
+
+	if (link.includes('\\')) {
+		return false;
+	}
+
+	// eslint-disable-next-line no-control-regex
+	if (/[\x00-\x1f\x7f]/.test(link) || link.trim() !== link) {
+		return false;
+	}
+
+	if (link.startsWith('/')) {
+		if (link.startsWith('//')) {
+			return false;
+		}
+
+		try {
+			return new URL(link, PRIMARY_ORIGIN).origin === PRIMARY_ORIGIN;
+		} catch {
+			return false;
+		}
+	}
+
+	try {
+		const scheme = new URL(link).protocol.toLowerCase();
+		return scheme === 'https:' || scheme === 'mailto:';
+	} catch {
+		return false;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Input size caps + history validation
+// ---------------------------------------------------------------------------
+
+export const MAX_MESSAGE_BYTES = 2048;
+export const MAX_JOBDESC_BYTES = 20480;
+export const MAX_HISTORY = 10;
+export const MAX_HISTORY_CONTENT_BYTES = 2048;
+
+// NOTE: 'system' is intentionally excluded — it is client-local UI state
+// (error/notice messages), never a genuine conversational turn, and is
+// filtered out of the outbound history payload by Chatbot.svelte before it
+// ever reaches this validator (see history construction there).
+export const HISTORY_ROLES = new Set(['user', 'model', 'assistant']);
+
+/**
+ * Validates a chat history payload: array shape, entry count, and per-entry
+ * role/content size. Pure function — safe to unit test directly.
+ *
+ * Residual risk (accepted this wave, see session notes): history entries are
+ * entirely client-supplied with no server-side session binding, so a
+ * `role: 'model'` entry only proves shape/size validity, not that the
+ * assistant actually said it. Guardrails run per-entry (handlers.ts), which
+ * also does not catch a trigger phrase split across multiple entries. Both
+ * are out of scope for this wave.
+ */
+export function validateHistory(history: unknown): { ok: boolean; error?: string } {
+	if (!Array.isArray(history)) {
+		return { ok: false, error: 'History must be an array' };
+	}
+
+	if (history.length > MAX_HISTORY) {
+		return { ok: false, error: `History must not exceed ${MAX_HISTORY} entries` };
+	}
+
+	for (const entry of history) {
+		if (!entry || typeof entry !== 'object') {
+			return { ok: false, error: 'Invalid history entry' };
+		}
+
+		const { role, content } = entry as { role?: unknown; content?: unknown };
+
+		if (typeof role !== 'string' || !HISTORY_ROLES.has(role)) {
+			return { ok: false, error: 'Invalid history entry role' };
+		}
+
+		if (typeof content !== 'string') {
+			return { ok: false, error: 'Invalid history entry content' };
+		}
+
+		if (Buffer.byteLength(content, 'utf8') > MAX_HISTORY_CONTENT_BYTES) {
+			return { ok: false, error: `History entry content must not exceed ${MAX_HISTORY_CONTENT_BYTES} bytes` };
+		}
+	}
+
+	return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Fit-finder / chat `variant` validation
+// ---------------------------------------------------------------------------
+
+// Verified against actual usage: handlers.ts `detectRoleFamily`/
+// `buildFallbackFitAnalysis`/the fit-finder prompt all operate on exactly
+// this 3-value set (types.ts `FitFinderRequest['variant']` /
+// `ChatRequest['variant']`). There is no 'default' variant in this codebase.
+export const ALLOWED_VARIANTS = ['leader', 'ops', 'builder'] as const;
+export type Variant = (typeof ALLOWED_VARIANTS)[number];
+
+/**
+ * Runtime validation for the `variant` field — the TypeScript request types
+ * are compile-time only and do not constrain the actual JSON body. Never
+ * interpolate an unvalidated `variant` value into a model prompt.
+ */
+export function isValidVariant(variant: unknown): variant is Variant {
+	return typeof variant === 'string' && (ALLOWED_VARIANTS as readonly string[]).includes(variant);
+}

--- a/site/functions/src/server.ts
+++ b/site/functions/src/server.ts
@@ -7,21 +7,62 @@
  * So each service handles POST at root (/).
  */
 import express from 'express';
+import { rateLimit, ipKeyGenerator } from 'express-rate-limit';
 import { handleChat } from './handlers.js';
 import { handleFitFinder } from './handlers.js';
+import { corsHeadersFor } from './security.js';
 
 const asyncHandler = (fn: express.RequestHandler) => (req: express.Request, res: express.Response, next: express.NextFunction) => {
 	Promise.resolve(fn(req, res, next)).catch(next);
 };
 
 const app = express();
-app.use(express.json());
+
+// Cloud Run sits behind a single Cloudflare→Cloud Run proxy hop, so
+// `trust proxy: 1` satisfies express-rate-limit's permissive-trust-proxy
+// validation without trusting an arbitrary/spoofable forwarded chain. The
+// rate limiter below keys on Cloudflare's `cf-connecting-ip` header (falling
+// back to `req.ip`), so correct client identification does not actually
+// depend on the exact hop count here — that's a Cloud-Run-runtime-specific
+// detail out of local verification scope; treat as a follow-up verify item
+// if limits are ever observed collapsing onto a shared proxy IP.
+app.set('trust proxy', 1);
+
+// CR-3: apply CORS headers to every response — including 400/413/429/500
+// error paths — by setting them in the earliest possible middleware, ahead
+// of the body parser and rate limiter. Per-handler `res.set(corsHeadersFor(req))`
+// calls further down are then a harmless, idempotent overwrite. Headers set
+// on `res` here persist through downstream middleware/error-handlers because
+// it's the same `res` object for the lifetime of the request.
+app.use((req, res, next) => {
+	res.set(corsHeadersFor(req));
+	next();
+});
+
+app.use(express.json({ limit: '64kb' }));
+
+const apiLimiter = rateLimit({
+	windowMs: 15 * 60 * 1000,
+	limit: 20,
+	standardHeaders: 'draft-7',
+	legacyHeaders: false,
+	keyGenerator: (req) => {
+		const cfConnectingIp = req.headers['cf-connecting-ip'];
+		const ip = Array.isArray(cfConnectingIp) ? cfConnectingIp[0] : cfConnectingIp;
+		// CR-4: use the library's own IPv6-safe fallback (ipKeyGenerator)
+		// instead of raw `req.ip`, so a) express-rate-limit's startup
+		// validation doesn't fire ERR_ERL_KEY_GEN_IPV6, and b) IPv6 clients on
+		// the fallback path (no cf-connecting-ip) are bucketed by subnet
+		// rather than by individual address.
+		return typeof ip === 'string' && ip ? ip : ipKeyGenerator(req.ip ?? '');
+	},
+});
 
 app.get('/', (_req, res) => {
 	res.status(200).json({ status: 'ok', service: 'briananderson-xyz-api' });
 });
 
-app.post('/', asyncHandler((req, res) => {
+app.post('/', apiLimiter, asyncHandler((req, res) => {
 	const fn = process.env.FUNCTION_TARGET || 'chat';
 	if (fn === 'fitfinder') {
 		return handleFitFinder(req, res);
@@ -36,9 +77,9 @@ app.options('/', asyncHandler((req, res) => {
 	return handleChat(req, res);
 }));
 
-app.post('/chat', asyncHandler((req, res) => handleChat(req, res)));
+app.post('/chat', apiLimiter, asyncHandler((req, res) => handleChat(req, res)));
 app.options('/chat', asyncHandler((req, res) => handleChat(req, res)));
-app.post('/fit-finder', asyncHandler((req, res) => handleFitFinder(req, res)));
+app.post('/fit-finder', apiLimiter, asyncHandler((req, res) => handleFitFinder(req, res)));
 app.options('/fit-finder', asyncHandler((req, res) => handleFitFinder(req, res)));
 
 app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {

--- a/site/functions/src/types.ts
+++ b/site/functions/src/types.ts
@@ -76,7 +76,7 @@ export interface ContentIndexPointer {
 
 export interface ChatRequest {
   message: string;
-  history?: Array<{ role: string; content: string }>;
+  history?: Array<{ role: 'user' | 'model' | 'assistant'; content: string }>;
   variant?: 'leader' | 'ops' | 'builder';
 }
 

--- a/site/package.json
+++ b/site/package.json
@@ -68,6 +68,7 @@
     "clsx": "^2.1.1",
     "dayjs": "^1.11.13",
     "gray-matter": "^4.0.3",
+    "isomorphic-dompurify": "^3.18.0",
     "lucide-svelte": "^0.462.0",
     "marked": "^17.0.1",
     "posthog-js": "^1.319.0",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       gray-matter:
         specifier: ^4.0.3
         version: 4.0.3
+      isomorphic-dompurify:
+        specifier: ^3.18.0
+        version: 3.18.0
       lucide-svelte:
         specifier: ^0.462.0
         version: 0.462.0(svelte@5.38.0)
@@ -125,9 +128,64 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@esbuild/aix-ppc64@0.25.8':
     resolution: {integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==}
@@ -478,6 +536,15 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -968,6 +1035,9 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -1046,10 +1116,18 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   dayjs@1.11.13:
     resolution: {integrity: sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==}
@@ -1071,6 +1149,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1099,6 +1180,9 @@ packages:
   dompurify@3.3.1:
     resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
 
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1110,6 +1194,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
@@ -1329,6 +1417,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -1380,11 +1472,18 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isomorphic-dompurify@3.18.0:
+    resolution: {integrity: sha512-ajp0D8laIHeoYlhBTevpE2HUhqWaqLXFk6K/wV3Ok8kDraBZpZsifwVWaY8IfJntMRIo1VSksgKV+lXyet9Q7A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -1400,6 +1499,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
@@ -1461,6 +1569,10 @@ packages:
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
   lucide-svelte@0.462.0:
     resolution: {integrity: sha512-BTY44UyXEhlakuPMS4w7NayKhDYARzmhEv3E2YchTiNZ/aySS0F2ktPscTlXRgSZ9xwqoozhnhO1oKhm/nnmqg==}
     peerDependencies:
@@ -1476,6 +1588,9 @@ packages:
     resolution: {integrity: sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   mdsvex@0.12.6:
     resolution: {integrity: sha512-pupx2gzWh3hDtm/iDW4WuCpljmyHbHi34r7ktOqpPGvyiM4MyfNgdJ3qMizXdgCErmvYC9Nn/qyjePy+4ss9Wg==}
@@ -1574,6 +1689,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1749,6 +1867,10 @@ packages:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -1784,6 +1906,10 @@ packages:
 
   sander@0.5.1:
     resolution: {integrity: sha512-3lVqBir7WuKDHGrKRDn/1Ye3kwpXaDOMsiRP1wd6wpZW56gJhsbp5RqQpA6JG/P+pkXizygnr1dKR8vzWaVsfA==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -1923,6 +2049,9 @@ packages:
     resolution: {integrity: sha512-cWF1Oc2IM/QbktdK89u5lt9MdKxRtQnRKnf2tq6KOhYuhLOd2hbMuTiJ+vWMzAeMDe81AzbCgLd4GVtOJ4fDRg==}
     engines: {node: '>=18'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
     peerDependencies:
@@ -1948,6 +2077,13 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@7.4.5:
+    resolution: {integrity: sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==}
+
+  tldts@7.4.5:
+    resolution: {integrity: sha512-RfEzKWcq5fHUOFq7J3rl3Oz6ylKGtcHqUznzj4EcXsxLSIjJcvpbXAQtWGeJQ0xKnimR5e0Cn+cn9TssfMzm+g==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1955,6 +2091,14 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -2002,6 +2146,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
@@ -2081,8 +2229,24 @@ packages:
       vite:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-vitals@4.2.4:
     resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -2103,6 +2267,13 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
@@ -2136,10 +2307,58 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
 
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
     optional: true
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@esbuild/aix-ppc64@0.25.8':
     optional: true
@@ -2342,6 +2561,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -2816,6 +3037,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   binary-extensions@2.3.0: {}
 
   brace-expansion@1.1.12:
@@ -2892,7 +3117,19 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   dayjs@1.11.13: {}
 
@@ -2903,6 +3140,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -2923,6 +3162,10 @@ snapshots:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.199: {}
@@ -2930,6 +3173,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  entities@8.0.0: {}
 
   es6-promise@3.3.1: {}
 
@@ -3213,6 +3458,12 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -3251,11 +3502,21 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-reference@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
   isexe@2.0.0: {}
+
+  isomorphic-dompurify@3.18.0:
+    dependencies:
+      dompurify: 3.4.11
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - canvas
 
   jackspeak@3.4.3:
     dependencies:
@@ -3273,6 +3534,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   json-buffer@3.0.1: {}
 
@@ -3317,6 +3604,8 @@ snapshots:
 
   lru-cache@10.4.3: {}
 
+  lru-cache@11.5.1: {}
+
   lucide-svelte@0.462.0(svelte@5.38.0):
     dependencies:
       svelte: 5.38.0
@@ -3329,6 +3618,8 @@ snapshots:
     optional: true
 
   marked@17.0.1: {}
+
+  mdn-data@2.27.1: {}
 
   mdsvex@0.12.6(svelte@5.38.0):
     dependencies:
@@ -3417,6 +3708,10 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
 
   path-exists@4.0.0: {}
 
@@ -3575,6 +3870,8 @@ snapshots:
 
   readdirp@4.1.2: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -3631,6 +3928,10 @@ snapshots:
       graceful-fs: 4.2.11
       mkdirp: 0.5.6
       rimraf: 2.7.1
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   section-matter@1.0.0:
     dependencies:
@@ -3764,6 +4065,8 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss-animate@1.0.7(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@25.0.7)(typescript@5.9.2))):
     dependencies:
       tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@25.0.7)(typescript@5.9.2))
@@ -3813,11 +4116,25 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tldts-core@7.4.5: {}
+
+  tldts@7.4.5:
+    dependencies:
+      tldts-core: 7.4.5
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   totalist@3.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.5
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.4.0(typescript@5.9.2):
     dependencies:
@@ -3869,6 +4186,8 @@ snapshots:
   typescript@5.9.2: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.28.0: {}
 
   unist-util-is@4.1.0: {}
 
@@ -3926,7 +4245,23 @@ snapshots:
     optionalDependencies:
       vite: 6.3.5(@types/node@25.0.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-vitals@4.2.4: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -3947,6 +4282,10 @@ snapshots:
       strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yaml@1.10.3: {}
 

--- a/site/src/lib/components/ChatMessage.svelte
+++ b/site/src/lib/components/ChatMessage.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import type { ChatMessage } from '$lib/types';
-	import { marked } from 'marked';
+	import { sanitizeMarkdown } from '$lib/utils/sanitize';
 
 	interface Props {
 		message: ChatMessage;
@@ -8,15 +8,10 @@
 
 	let { message }: Props = $props();
 
-	// Configure marked for safe rendering
-	marked.setOptions({
-		breaks: true,
-		gfm: true
-	});
-
+	// Render assistant markdown through DOMPurify-sanitized HTML
 	const renderedContent = $derived(
 		message.role === 'assistant'
-			? marked.parse(message.content)
+			? sanitizeMarkdown(message.content)
 			: message.content
 	);
 

--- a/site/src/lib/components/Chatbot.svelte
+++ b/site/src/lib/components/Chatbot.svelte
@@ -91,7 +91,14 @@
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify({
 					message: content,
-					history: messages.slice(-5) // Last 5 messages for context
+					// CR-2: only 'user'/'assistant' turns are genuine conversational
+					// history; 'system' entries (local error/notice UI state, e.g.
+					// below) are never sent — the server's validateHistory rejects
+					// role 'system', so leaving one in would 400 every send until
+					// it aged out of the last-5 window.
+					history: messages
+						.filter((m) => m.role === 'user' || m.role === 'assistant')
+						.slice(-5) // Last 5 messages for context
 				})
 			});
 

--- a/site/src/lib/utils/sanitize.ts
+++ b/site/src/lib/utils/sanitize.ts
@@ -1,0 +1,24 @@
+/**
+ * Markdown sanitization utility for AI chat output
+ * Renders markdown to HTML and strips dangerous content (scripts, event
+ * handlers, javascript: URLs) before it is injected via {@html}
+ */
+
+import { marked } from 'marked';
+import DOMPurify from 'isomorphic-dompurify';
+
+marked.setOptions({
+  breaks: true,
+  gfm: true
+});
+
+/**
+ * Convert raw markdown to sanitized, safe-to-render HTML
+ * @param raw - Raw markdown string (e.g. assistant chat message content)
+ * @returns Sanitized HTML string safe for use with {@html}
+ */
+export function sanitizeMarkdown(raw: string): string {
+  if (typeof raw !== 'string' || raw.length === 0) return '';
+  const html = marked.parse(raw) as string;
+  return DOMPurify.sanitize(html);
+}

--- a/site/svelte.config.js
+++ b/site/svelte.config.js
@@ -25,7 +25,8 @@ const config = {
     // Crawl all pages, but ignore 404s for the Decap CMS admin which is served from static/admin/
     prerender: {
       entries: ['*'],
-      handleMissingId: 'warn'
+      handleMissingId: 'warn',
+      origin: 'https://briananderson.xyz'
     },
     alias: {
       $lib: 'src/lib'


### PR DESCRIPTION
## Summary

Wave 1 of a site audit — the highest-impact **correctness, security, and deploy-reliability** fixes. Delegated implementation (4 parallel workers) with independent code + security + dependency review; **every HIGH finding was caught by review and re-verified clean in the same iteration**.

## What changed

**SEO / correctness**
- `kit.prerender.origin` set so every blog/project page emits real `https://briananderson.xyz` canonical / `og:url` / `twitter:url` instead of the `sveltekit-prerender` placeholder host that was breaking indexing.

**Chat / XSS**
- Assistant markdown now rendered through a DOMPurify sanitizer instead of raw `{@html marked.parse(...)}`.
- Outbound chat history filtered to `user`/`assistant` roles (fixes a regression where local error messages permanently 400'd the chat).

**Public API hardening (Cloud Run functions)**
- Security helpers extracted to `security.ts` with **34 committed `node:test` cases, now run in CI**.
- CORS allowlist + `Vary: Origin` (replaces wildcard `*`), applied early so error responses carry headers cross-origin.
- Per-IP rate limiting (20 / 15 min, keyed on `cf-connecting-ip`), `trust proxy`, 64 KB body cap.
- Input caps (message 2 KB, jobDescription 20 KB) + history validation; guardrails run on **all** user fields.
- CTA link scheme whitelist resolved against the site origin — closes a `/\evil.com` **open-redirect bypass** flagged by review.
- Runtime `variant` validation (closes a prompt-injection path).

**CI/CD**
- Automatic rollback fixed — it was re-deploying the *failed* build (missing `--dir site/build/`).
- `AI_EVAL_MIN_PASS_RATE` pinned to `0.95` (was defaulting to an unreachable `1.00`).

## Verification
- `pnpm run build` (0 `sveltekit-prerender` in output), `svelte-check` 0 errors, functions `tsc` 0 errors, functions `pnpm test` 34/34.
- Empirical CTA-bypass probe + live CORS / rate-limit / variant runtime probes.
- 16/16 acceptance criteria PASS; review + verify clean in the same iteration.

## Not included (tracked for later waves)
- 413→500 error-middleware status coercion (monitoring fidelity, non-blocking).
- Pre-existing dependency advisories (`protobufjs`, `qs`, `posthog-js`→`dompurify@3.3.1`).
- SEO hygiene (sitemap lastmod, og:image), AI affordances (markdown mirrors, `llms-full.txt`), broader CI hardening, Firebase-remnant cleanup, content fixes.

> Note: `site/src/lib/components/Navbar.svelte` had a pre-existing uncommitted change and was deliberately left out of this branch.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp