### PR TITLE
Wave 2: SEO + AI-readability (stacked on #52)

### DIFF
--- a/site/content/interests.yaml
+++ b/site/content/interests.yaml
@@ -108,4 +108,4 @@ sections:
       - heading: "Family"
         body: "Dad first. Everything else is secondary."
       - heading: "Everything else"
-        body: "Disc golf, concerts. friends, food, and traveling."
+        body: "Disc golf, concerts, friends, food, and traveling."

--- a/site/content/projects/gfs-ordering-platform.md
+++ b/site/content/projects/gfs-ordering-platform.md
@@ -33,7 +33,7 @@ I came into this engagement as a **Technical Principal**, leading the product ar
 - **Speed to value:** Feature requests went from months-long backlogs to **production in under 24 hours**.
 - **Reliability:** **Zero customer-facing downtime** through the entire migration and beyond.
 - **Scale:** The platform supported 100,000+ B2B customers with a mobile-first ordering experience, driving record digital sales during global supply chain disruptions.
-- **Canada expansion:** The platform's adoption metrics directly supported GFS's growth, going from a **25% to 96% adoption increase** in Canada.
+- **Canada expansion:** The platform's adoption metrics directly supported GFS's growth, with digital adoption in Canada climbing from **25% to 96%**.
 
 ## Recognition
 

--- a/site/content/projects/kiro-agent-workflows.md
+++ b/site/content/projects/kiro-agent-workflows.md
@@ -28,7 +28,7 @@ I wanted repeatable AI workflows that improved engineering output instead of cre
 - Reduced my own administrative overhead by roughly **4 hours per week**.
 - Created a more reliable personal workflow for using AI as a systems-thinking partner rather than an autocomplete layer.
 
-## Why Employers Should Care
+## Why It Matters
 
 This work demonstrates a practical point: productive AI use is not about collecting prompts. It is about designing workflows, constraints, evaluation loops, and operating habits that make the output more useful and less noisy.
 

--- a/site/functions/src/server.ts
+++ b/site/functions/src/server.ts
@@ -82,9 +82,9 @@ app.options('/chat', asyncHandler((req, res) => handleChat(req, res)));
 app.post('/fit-finder', apiLimiter, asyncHandler((req, res) => handleFitFinder(req, res)));
 app.options('/fit-finder', asyncHandler((req, res) => handleFitFinder(req, res)));
 
-app.use((err: Error, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+app.use((err: Error & { status?: number; statusCode?: number }, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
 	console.error('Unhandled error:', err);
-	res.status(500).json({ error: 'Internal server error' });
+	res.status(err.status ?? err.statusCode ?? 500).json({ error: 'Internal server error' });
 });
 
 const PORT = process.env.PORT || 8080;

--- a/site/src/lib/components/Homepage.svelte
+++ b/site/src/lib/components/Homepage.svelte
@@ -16,6 +16,7 @@
     "@context": "https://schema.org",
     "@type": "Person",
     "name": resume.name,
+    "jobTitle": formatJobTitles(resume.jobTitles),
     "description": resume.tagline,
     "url": "https://briananderson.xyz",
     "sameAs": [

--- a/site/src/lib/components/SEO.svelte
+++ b/site/src/lib/components/SEO.svelte
@@ -19,12 +19,14 @@
         canonical ||
         ($page.url ? `${$page.url.origin}${$page.url.pathname}` : undefined);
 
-    // Construct absolute image URL if provided
+    // Construct absolute image URL if provided; fall back to the default
+    // social image (headshot) so every page emits og:image / twitter:image.
+    const defaultImage = "/headshot.jpg";
     $: finalImage = image
         ? image.startsWith("http")
             ? image
             : `${$page.url.origin}${image}`
-        : undefined;
+        : `${$page.url.origin}${defaultImage}`;
 
     // Combine tags and keywords for meta keywords
     $: metaKeywords = [...(tags || []), ...(keywords || [])].join(", ");

--- a/site/src/lib/server/resumeMarkdown.ts
+++ b/site/src/lib/server/resumeMarkdown.ts
@@ -1,0 +1,115 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+import path from 'path';
+import type { Resume } from '$lib/types';
+
+export function loadResume(): Resume {
+	const resumePath = path.resolve('content/resume.yaml');
+	const resumeContents = fs.readFileSync(resumePath, 'utf-8');
+	return yaml.load(resumeContents) as Resume;
+}
+
+export function buildResumeMarkdown(resume: Resume): string {
+	const jobTitle = resume.jobTitles.join(' & ');
+
+	const experience = resume.experience
+		.map((job) => {
+			const highlights = job.highlights
+				.map((h) => {
+					const text = typeof h === 'string' ? h : h.text;
+					const link = typeof h === 'string' ? undefined : h.link;
+					return `- ${text}${link ? ` (${link})` : ''}`;
+				})
+				.join('\n');
+			return `### ${job.role} — ${job.company}
+*${job.start_date} – ${job.end_date ?? 'Present'}* | ${job.location}
+
+${job.description ?? ''}
+
+${highlights}`;
+		})
+		.join('\n\n');
+
+	const earlyCareerEntries = resume['early-career'] ?? [];
+	const earlyCareer = earlyCareerEntries
+		.map(
+			(career) =>
+				`### ${career.role} — ${career.company}
+*${career.start_date} – ${career.end_date ?? 'Present'}* | ${career.location}`
+		)
+		.join('\n\n');
+
+	const skills = Object.entries(resume.skills)
+		.map(([category, items]) => `**${category}:** ${items.map((s) => s.name).join(', ')}`)
+		.join('\n');
+
+	const education = resume.education
+		.map(
+			(edu) =>
+				`- **${edu.school}** — ${edu.degree} (${edu.start_date} – ${edu.end_date ?? 'Present'}), ${edu.location}`
+		)
+		.join('\n');
+
+	const certificates = resume.certificates
+		.map(
+			(cert) =>
+				`- ${cert.name} (${cert.start_date}${cert.end_date ? ` – ${cert.end_date}` : ''})${cert.url ? ` — ${cert.url}` : ''}`
+		)
+		.join('\n');
+
+	const contactParts = [resume.location, resume.email].filter(
+		(part): part is string => Boolean(part)
+	);
+	const contactLine = contactParts.length > 0 ? `\n\n${contactParts.join(' | ')}` : '';
+
+	const header = `# ${resume.name}
+
+**${jobTitle}**
+
+> ${resume.tagline}${contactLine}`;
+
+	const summarySection = `## Summary
+
+${resume.summary}`;
+
+	const missionSection = resume.mission
+		? `## Mission
+
+${resume.mission}`
+		: null;
+
+	const experienceSection = `## Experience
+
+${experience}`;
+
+	const earlyCareerSection = earlyCareerEntries.length > 0
+		? `## Early Career
+
+${earlyCareer}`
+		: null;
+
+	const skillsSection = `## Skills
+
+${skills}`;
+
+	const educationSection = `## Education
+
+${education}`;
+
+	const certificatesSection = `## Certificates
+
+${certificates}`;
+
+	const sections = [
+		header,
+		summarySection,
+		missionSection,
+		experienceSection,
+		earlyCareerSection,
+		skillsSection,
+		educationSection,
+		certificatesSection
+	].filter((section): section is string => Boolean(section));
+
+	return `${sections.join('\n\n')}\n`;
+}

--- a/site/src/routes/+layout.svelte
+++ b/site/src/routes/+layout.svelte
@@ -18,6 +18,28 @@
   import { PUBLIC_POSTHOG_KEY, PUBLIC_POSTHOG_HOST } from "$env/static/public";
   import ExternalLinkModal from "$lib/components/ExternalLinkModal.svelte";
 
+  const siteUrl = "https://briananderson.xyz";
+  // Site-wide WebSite JSON-LD (no SearchAction: no site search endpoint exists).
+  // Built as a `<script>` string (not a Svelte block) to avoid ESLint/Svelte
+  // parser confusion, matching the pattern in Homepage.svelte / ResumePage.svelte.
+  const websiteJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: "Brian Anderson",
+    url: siteUrl,
+    author: {
+      "@type": "Person",
+      name: "Brian Anderson",
+      url: siteUrl
+    },
+    publisher: {
+      "@type": "Person",
+      name: "Brian Anderson",
+      url: siteUrl
+    }
+  };
+  const websiteJsonLdTag = `<${"script"} type="application/ld+json">${JSON.stringify(websiteJsonLd, null, 2)}</${"script"}>`;
+
   let quickActionsVisible = $state(false);
   let shortcutsHelpVisible = $state(false);
   let chatbotVisible = $state(false);
@@ -184,6 +206,7 @@
 <svelte:head>
   <link rel="llms" href="/llms.txt" />
   <link rel="alternate" type="application/json" href="/resume.json" />
+  {@html websiteJsonLdTag}
 </svelte:head>
 
 <div

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <SEO
-  title="Brian Anderson"
+  title="Brian Anderson — AI Systems Architect & Enterprise Solutions Architect"
   description="Enterprise architect and hands-on builder focused on AI platforms, cloud modernization, and developer productivity."
   canonical={getCanonicalUrl("/")}
 />

--- a/site/src/routes/blog/+page.svelte
+++ b/site/src/routes/blog/+page.svelte
@@ -2,7 +2,7 @@
   import { page } from "$app/stores";
   import SEO from "$lib/components/SEO.svelte";
   import type { ContentItem } from "$lib/types";
-  import { addVariant, getVariant } from "$lib/utils/variantLink";
+  import { addVariant, getVariant, getCanonicalUrl } from "$lib/utils/variantLink";
   import { onMount } from "svelte";
 
   export let data: { posts: ContentItem[] };
@@ -17,7 +17,7 @@
 <SEO
   title="Blog | Brian Anderson"
   description="dumping_core_memory.log - Thoughts, tutorials, and technical articles."
-  canonical="https://briananderson.xyz/blog"
+  canonical={getCanonicalUrl("/blog/")}
 />
 
 <section class="mx-auto max-w-6xl px-4 py-16">

--- a/site/src/routes/blog/[slug].md/+server.ts
+++ b/site/src/routes/blog/[slug].md/+server.ts
@@ -1,0 +1,36 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+// Raw markdown mirror of blog/[slug]. Sibling extension route, same pattern
+// already used in this repo for resume/+page.svelte + resume.json/+server.ts.
+const modules = import.meta.glob('/content/blog/**/*.md', {
+	eager: true,
+	query: '?raw',
+	import: 'default'
+}) as Record<string, string>;
+
+function slugFromPath(path: string): string {
+	return path.slice(path.lastIndexOf('/') + 1).replace(/\.md$/, '');
+}
+
+export const prerender = true;
+
+// Enumerate every blog slug so the prerenderer emits a .md URL per post
+// (nothing links to these routes directly, so they'd otherwise be skipped).
+export const entries = () => {
+	return Object.keys(modules).map((path) => ({ slug: slugFromPath(path) }));
+};
+
+export const GET: RequestHandler = ({ params }) => {
+	const match = Object.keys(modules).find((p) => p.endsWith(`/${params.slug}.md`));
+
+	if (!match) {
+		error(404, 'Not found');
+	}
+
+	return new Response(modules[match], {
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8'
+		}
+	});
+};

--- a/site/src/routes/blog/[slug]/+page.svelte
+++ b/site/src/routes/blog/[slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import SEO from "$lib/components/SEO.svelte";
   import ImageGallery from "$lib/components/ImageGallery.svelte";
   import ProjectLinks from "$lib/components/ProjectLinks.svelte";
@@ -9,7 +10,55 @@
   }
 
   let { data }: Props = $props();
+
+  const siteUrl = "https://briananderson.xyz";
+
+  // BlogPosting + BreadcrumbList JSON-LD, sourced from content frontmatter
+  // (data.metadata) via the existing blog loader. Built as a `<script>` string
+  // (not a Svelte block) to avoid ESLint/Svelte parser confusion, matching the
+  // pattern in Homepage.svelte / ResumePage.svelte.
+  let jsonLdTag = $derived.by(() => {
+    if (!data?.html || !data?.metadata) return "";
+
+    const canonicalUrl = `${siteUrl}/blog/${page.params.slug}/`;
+    const keywordsList = [
+      ...(data.metadata.tags || []),
+      ...(data.metadata.keywords || [])
+    ];
+
+    const blogPostingJsonLd = {
+      "@context": "https://schema.org",
+      "@type": "BlogPosting",
+      headline: data.metadata.title,
+      description: data.metadata.summary || data.metadata.title,
+      datePublished: data.metadata.date,
+      author: {
+        "@type": "Person",
+        name: "Brian Anderson",
+        url: siteUrl
+      },
+      url: canonicalUrl,
+      mainEntityOfPage: canonicalUrl,
+      ...(keywordsList.length ? { keywords: keywordsList.join(", ") } : {})
+    };
+
+    const breadcrumbJsonLd = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: `${siteUrl}/` },
+        { "@type": "ListItem", position: 2, name: "Blog", item: `${siteUrl}/blog/` },
+        { "@type": "ListItem", position: 3, name: data.metadata.title, item: canonicalUrl }
+      ]
+    };
+
+    return `<${"script"} type="application/ld+json">${JSON.stringify([blogPostingJsonLd, breadcrumbJsonLd], null, 2)}</${"script"}>`;
+  });
 </script>
+
+<svelte:head>
+  {@html jsonLdTag}
+</svelte:head>
 
 {#if data?.html}
   <SEO

--- a/site/src/routes/following/+page.svelte
+++ b/site/src/routes/following/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { browser } from "$app/environment";
   import { goto } from "$app/navigation";
+  import { getCanonicalUrl } from "$lib/utils/variantLink";
 
   if (browser) {
     goto("/interests/", { replaceState: true });
@@ -9,5 +10,5 @@
 
 <svelte:head>
   <meta http-equiv="refresh" content="0;url=/interests/" />
-  <link rel="canonical" href="/interests/" />
+  <link rel="canonical" href={getCanonicalUrl("/interests/")} />
 </svelte:head>

--- a/site/src/routes/interests/+page.svelte
+++ b/site/src/routes/interests/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import SEO from "$lib/components/SEO.svelte";
+  import { getCanonicalUrl } from "$lib/utils/variantLink";
 
   interface Creator {
     name: string;
@@ -87,7 +88,7 @@
   <SEO
     title="Interests | Brian Anderson"
     description="Who I follow, my setup, and what I'm into outside of work."
-    canonical="https://briananderson.xyz/interests"
+    canonical={getCanonicalUrl("/interests/")}
   />
 
   <section class="mx-auto max-w-4xl px-4 py-16">

--- a/site/src/routes/llms-full.txt/+server.ts
+++ b/site/src/routes/llms-full.txt/+server.ts
@@ -1,0 +1,89 @@
+import fs from 'fs';
+import yaml from 'js-yaml';
+import path from 'path';
+import { PUBLIC_SITE_URL } from '$env/static/public';
+import type { ContentMetadata, Resume } from '$lib/types';
+import { buildResumeMarkdown } from '$lib/server/resumeMarkdown';
+
+interface Personal {
+	interests: { name: string; description: string }[];
+	values: string[];
+	hobbies: { name: string; details: string }[];
+}
+
+export const prerender = true;
+
+export const GET = async () => {
+	const resumePath = path.resolve('content/resume.yaml');
+	const resumeContents = fs.readFileSync(resumePath, 'utf-8');
+	const resume = yaml.load(resumeContents) as Resume;
+
+	const personalPath = path.resolve('content/personal.yaml');
+	const personalContents = fs.readFileSync(personalPath, 'utf-8');
+	const personal = yaml.load(personalContents) as Personal;
+
+	const overview = `# briananderson.xyz — Full Content Archive
+
+This is a single, complete text export of briananderson.xyz for AI agents and crawlers: site overview, full resume, and the raw Markdown source of every blog post and project. For a shorter, links-only summary see ${PUBLIC_SITE_URL}/llms.txt.
+
+**Owner:** Brian Anderson
+**Location:** ${resume.location}
+**Email:** ${resume.email}
+
+## About Brian
+
+${resume.summary}
+
+### Personal Interests
+${personal.interests.map((i) => `- **${i.name}:** ${i.description}`).join('\n')}
+
+### Core Values
+${personal.values.map((v: string) => `- ${v}`).join('\n')}
+
+### Hobbies
+${personal.hobbies.map((h) => `- **${h.name}:** ${h.details}`).join('\n')}
+`;
+
+	const resumeMarkdown = `---
+
+# Full Resume
+
+${buildResumeMarkdown(resume)}`;
+
+	const blogModules = import.meta.glob('/content/blog/**/*.md', { as: 'raw', eager: true }) as Record<string, string>;
+	const projectModules = import.meta.glob('/content/projects/**/*.md', { as: 'raw', eager: true }) as Record<string, string>;
+	const metaModules = {
+		...(import.meta.glob('/content/blog/**/*.md', { eager: true }) as Record<string, { metadata: ContentMetadata }>),
+		...(import.meta.glob('/content/projects/**/*.md', { eager: true }) as Record<string, { metadata: ContentMetadata }>)
+	};
+
+	const renderSection = (title: string, modules: Record<string, string>) =>
+		`---
+
+# ${title}
+
+${Object.entries(modules)
+	.map(([filePath, raw]) => {
+		const slug = filePath.replace('/content', '').replace('.md', '');
+		const meta = metaModules[filePath]?.metadata;
+		return `---
+
+## ${meta?.title ?? slug}
+
+Source: ${PUBLIC_SITE_URL}${slug}/
+
+${raw}`;
+	})
+	.join('\n\n')}`;
+
+	const blogSection = renderSection('Blog Posts', blogModules);
+	const projectSection = renderSection('Projects', projectModules);
+
+	const content = [overview, resumeMarkdown, blogSection, projectSection].join('\n\n');
+
+	return new Response(content, {
+		headers: {
+			'Content-Type': 'text/plain; charset=utf-8'
+		}
+	});
+};

--- a/site/src/routes/llms.txt/+server.ts
+++ b/site/src/routes/llms.txt/+server.ts
@@ -39,15 +39,70 @@ Personal portfolio and professional site for Brian Anderson - Technical Director
  ### Resume Data
  - **Resume Page:** ${PUBLIC_SITE_URL}/resume/ - Human-readable resume with JSON-LD schema markup
  - **JSON Resume:** ${PUBLIC_SITE_URL}/resume.json - JSONResume 1.0.0 schema for programmatic parsing
+ - **Markdown Resume:** ${PUBLIC_SITE_URL}/resume.md - Plain-text/Markdown resume for LLM ingestion
  - **Resume Variants:**
-   - Leader: ${PUBLIC_SITE_URL}/resume/ - Focus on leadership and architecture
-   - Ops: ${PUBLIC_SITE_URL}/ops/resume/ - Focus on DevOps/SRE
-   - Builder: ${PUBLIC_SITE_URL}/builder/resume/ - Focus on hands-on technical work
+   - Leader: ${PUBLIC_SITE_URL}/resume/ - Focus on leadership and architecture (JSON: ${PUBLIC_SITE_URL}/resume.json)
+   - Ops: ${PUBLIC_SITE_URL}/ops/resume/ - Focus on DevOps/SRE (JSON: ${PUBLIC_SITE_URL}/ops/resume.json)
+   - Builder: ${PUBLIC_SITE_URL}/builder/resume/ - Focus on hands-on technical work (JSON: ${PUBLIC_SITE_URL}/builder/resume.json)
 
 ### Content
 - **Blog:** ${PUBLIC_SITE_URL}/blog/ - Technical articles and tutorials
+- **Blog Markdown Mirrors:** ${PUBLIC_SITE_URL}/blog/{slug}.md - Raw Markdown source of each post
 - **Projects:** ${PUBLIC_SITE_URL}/projects/ - Portfolio of software development work
+- **Project Markdown Mirrors:** ${PUBLIC_SITE_URL}/projects/{slug}.md - Raw Markdown source of each project
+- **Interests:** ${PUBLIC_SITE_URL}/interests/ - Personal interests, values, and hobbies
 - **RSS Feed:** ${PUBLIC_SITE_URL}/rss.xml - Blog posts in RSS format
+- **Content Index:** ${PUBLIC_SITE_URL}/content-index.json - Structured JSON index of skills, experience, projects, and blog posts for agent tooling
+- **Whole-Site Text Archive:** ${PUBLIC_SITE_URL}/llms-full.txt - Single document with the site overview, full resume, and every blog/project body concatenated
+
+## Agent API
+
+Live, CORS-enabled Cloud Run endpoints for programmatic interaction. Also reachable through the site's same-origin proxy routes (\`${PUBLIC_SITE_URL}/api/chat\`, \`${PUBLIC_SITE_URL}/api/fit-finder\`), which forward the request body as-is.
+
+### POST https://api.briananderson.xyz/chat
+Conversational Q&A grounded in Brian's resume/project/blog content.
+
+Request:
+\`\`\`json
+{
+  "message": "string (required)",
+  "history": [{ "role": "user | model | assistant", "content": "string" }],
+  "variant": "leader | ops | builder"
+}
+\`\`\`
+
+Response:
+\`\`\`json
+{ "response": "string" }
+\`\`\`
+
+### POST https://api.briananderson.xyz/fit-finder
+Analyzes a pasted job description against Brian's background and returns a fit assessment.
+
+Request:
+\`\`\`json
+{
+  "jobDescription": "string (required)",
+  "variant": "leader | ops | builder"
+}
+\`\`\`
+
+Response:
+\`\`\`json
+{
+  "analysis": {
+    "fitScore": "number (0-100)",
+    "fitLevel": "good | maybe | not",
+    "confidence": "low | medium | high",
+    "matchingSkills": [{ "name": "string", "context": "string" }],
+    "matchingExperience": [{ "role": "string", "company": "string", "dateRange": "string", "relevance": "string" }],
+    "gaps": ["string"],
+    "analysis": "string",
+    "resumeVariantRecommendation": "leader | ops | builder",
+    "cta": { "text": "string", "link": "string" }
+  }
+}
+\`\`\`
 
 ## About Brian
 

--- a/site/src/routes/projects/+page.svelte
+++ b/site/src/routes/projects/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { page } from "$app/stores";
   import { browser } from "$app/environment";
-  import { addVariant } from "$lib/utils/variantLink";
+  import { addVariant, getCanonicalUrl } from "$lib/utils/variantLink";
   import SEO from "$lib/components/SEO.svelte";
 
   function getVariant(url: URL): string | null {
@@ -15,7 +15,7 @@
 <SEO
   title="Projects | Brian Anderson"
   description="A collection of deployed systems, experiments, and open source projects."
-  canonical="https://briananderson.xyz/projects"
+  canonical={getCanonicalUrl("/projects/")}
 />
 
 <section class="mx-auto max-w-6xl px-4 py-16">

--- a/site/src/routes/projects/[slug].md/+server.ts
+++ b/site/src/routes/projects/[slug].md/+server.ts
@@ -1,0 +1,36 @@
+import { error } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+// Raw markdown mirror of projects/[slug]. Sibling extension route, same
+// pattern already used in this repo for resume/+page.svelte + resume.json/+server.ts.
+const modules = import.meta.glob('/content/projects/**/*.md', {
+	eager: true,
+	query: '?raw',
+	import: 'default'
+}) as Record<string, string>;
+
+function slugFromPath(path: string): string {
+	return path.slice(path.lastIndexOf('/') + 1).replace(/\.md$/, '');
+}
+
+export const prerender = true;
+
+// Enumerate every project slug so the prerenderer emits a .md URL per project
+// (nothing links to these routes directly, so they'd otherwise be skipped).
+export const entries = () => {
+	return Object.keys(modules).map((path) => ({ slug: slugFromPath(path) }));
+};
+
+export const GET: RequestHandler = ({ params }) => {
+	const match = Object.keys(modules).find((p) => p.endsWith(`/${params.slug}.md`));
+
+	if (!match) {
+		error(404, 'Not found');
+	}
+
+	return new Response(modules[match], {
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8'
+		}
+	});
+};

--- a/site/src/routes/projects/[slug]/+page.svelte
+++ b/site/src/routes/projects/[slug]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { page } from "$app/state";
   import SEO from "$lib/components/SEO.svelte";
   import ImageGallery from "$lib/components/ImageGallery.svelte";
   import VisualArchive from "$lib/components/VisualArchive.svelte";
@@ -10,7 +11,56 @@
   }
 
   let { data }: Props = $props();
+
+  const siteUrl = "https://briananderson.xyz";
+
+  // CreativeWork + BreadcrumbList JSON-LD, sourced from content frontmatter
+  // (data.metadata) via the existing projects loader. Built as a `<script>`
+  // string (not a Svelte block) to avoid ESLint/Svelte parser confusion,
+  // matching the pattern in Homepage.svelte / ResumePage.svelte.
+  let jsonLdTag = $derived.by(() => {
+    if (!data?.html || !data?.metadata) return "";
+
+    const canonicalUrl = `${siteUrl}/projects/${page.params.slug}/`;
+    const keywordsList = [
+      ...(data.metadata.tags || []),
+      ...(data.metadata.keywords || [])
+    ];
+
+    const creativeWorkJsonLd = {
+      "@context": "https://schema.org",
+      "@type": "CreativeWork",
+      name: data.metadata.title,
+      headline: data.metadata.title,
+      description: data.metadata.summary || data.metadata.title,
+      datePublished: data.metadata.date,
+      author: {
+        "@type": "Person",
+        name: "Brian Anderson",
+        url: siteUrl
+      },
+      url: canonicalUrl,
+      mainEntityOfPage: canonicalUrl,
+      ...(keywordsList.length ? { keywords: keywordsList.join(", ") } : {})
+    };
+
+    const breadcrumbJsonLd = {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "Home", item: `${siteUrl}/` },
+        { "@type": "ListItem", position: 2, name: "Projects", item: `${siteUrl}/projects/` },
+        { "@type": "ListItem", position: 3, name: data.metadata.title, item: canonicalUrl }
+      ]
+    };
+
+    return `<${"script"} type="application/ld+json">${JSON.stringify([creativeWorkJsonLd, breadcrumbJsonLd], null, 2)}</${"script"}>`;
+  });
 </script>
+
+<svelte:head>
+  {@html jsonLdTag}
+</svelte:head>
 
 {#if data?.html}
   <SEO

--- a/site/src/routes/resume.md/+server.ts
+++ b/site/src/routes/resume.md/+server.ts
@@ -1,0 +1,14 @@
+import { loadResume, buildResumeMarkdown } from '$lib/server/resumeMarkdown';
+
+export const prerender = true;
+
+export const GET = async () => {
+	const resume = loadResume();
+	const markdown = buildResumeMarkdown(resume);
+
+	return new Response(markdown, {
+		headers: {
+			'Content-Type': 'text/markdown; charset=utf-8'
+		}
+	});
+};

--- a/site/src/routes/robots.txt/+server.ts
+++ b/site/src/routes/robots.txt/+server.ts
@@ -6,9 +6,11 @@ export const GET = async () => {
   const robots = `# AI Content Signals Compliant
 # See https://contentsignals.org/ for more information
 
-# Allow all general crawlers
+# Allow all general crawlers; block API/admin routes
 User-agent: *
 Allow: /
+Disallow: /api/
+Disallow: /admin/
 
 # OpenAI GPTBot - AI crawling allowed
 User-agent: GPTBot
@@ -33,11 +35,6 @@ Allow: /
 # Cohere AI
 User-agent: CohereBot
 Allow: /
-
-# Other AI crawlers
-User-agent: *
-Disallow: /api/
-Disallow: /admin/
 
 Sitemap: ${PUBLIC_SITE_URL}/sitemap.xml`;
   

--- a/site/src/routes/rss.xml/+server.ts
+++ b/site/src/routes/rss.xml/+server.ts
@@ -15,11 +15,13 @@ export const GET = async () => {
     };
   }).sort((a, b) => +new Date(b.date) - +new Date(a.date));
   const feed = `<?xml version="1.0" encoding="UTF-8"?>
-  <rss version="2.0">
+  <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
       <title>Brian Anderson — Blog</title>
       <link>${site}</link>
+      <atom:link href="${site}/rss.xml" rel="self" type="application/rss+xml"/>
       <description>Writing by Brian Anderson</description>
+      <language>en-us</language>
       ${items.map(i => `
         <item>
           <title><![CDATA[${i.title}]]></title>

--- a/site/src/routes/sitemap.xml/+server.ts
+++ b/site/src/routes/sitemap.xml/+server.ts
@@ -1,20 +1,36 @@
 import { PUBLIC_SITE_URL } from '$env/static/public';
+import type { ContentMetadata } from '$lib/types';
 
 export const prerender = true;
 const site = PUBLIC_SITE_URL;
 export const GET = async () => {
-  const staticPages = ['/', '/blog', '/projects', '/resume', '/ops', '/builder', '/ops/resume', '/builder/resume'];
+  const buildDate = new Date().toISOString().split('T')[0];
+  const staticPages = ['/', '/blog', '/projects', '/interests', '/following', '/resume', '/ops', '/builder', '/ops/resume', '/builder/resume'];
   const aiPages = ['/llms.txt', '/resume.json'];
   const mBlog = import.meta.glob('/content/blog/**/*.md', { eager: true });
   const mProj = import.meta.glob('/content/projects/**/*.md', { eager: true });
-  const posts = Object.keys(mBlog).map((p) => p.replace('/content', '').replace('.md', ''));
-  const projs = Object.keys(mProj).map((p) => p.replace('/content', '').replace('.md', ''));
-  const urls = [...staticPages, ...aiPages, ...posts, ...projs].map((p) =>
-    aiPages.includes(p) ? `${site}${p}` : `${site}${p}${p === '/' ? '' : '/'}`
-  );
+
+  const contentEntries = (mod: Record<string, unknown>) =>
+    Object.entries(mod).map(([p, mdl]) => {
+      const m = mdl as { metadata: ContentMetadata };
+      return {
+        path: p.replace('/content', '').replace('.md', ''),
+        lastmod: m.metadata?.date ? new Date(m.metadata.date).toISOString().split('T')[0] : buildDate
+      };
+    });
+
+  const staticEntries = [...staticPages, ...aiPages].map((p) => ({ path: p, lastmod: buildDate }));
+  const posts = contentEntries(mBlog);
+  const projs = contentEntries(mProj);
+
+  const urls = [...staticEntries, ...posts, ...projs].map((e) => ({
+    loc: aiPages.includes(e.path) ? `${site}${e.path}` : `${site}${e.path}${e.path === '/' ? '' : '/'}`,
+    lastmod: e.lastmod
+  }));
+
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
   <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-    ${urls.map(u => `<url><loc>${u}</loc></url>`).join('')}
+    ${urls.map(u => `<url><loc>${u.loc}</loc><lastmod>${u.lastmod}</lastmod></url>`).join('')}
   </urlset>`;
   return new Response(xml, { headers: { 'Content-Type': 'application/xml' } });
 };

--- a/site/static/.well-known/security.txt
+++ b/site/static/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:brian@briananderson.xyz
+# Expires needs a periodic manual bump (RFC 9116 recommends well under 1 year out).
+Expires: 2027-07-01T00:00:00.000Z
+Preferred-Languages: en

--- a/site/static/humans.txt
+++ b/site/static/humans.txt
@@ -1,0 +1,17 @@
+/* TEAM */
+	Developer: Brian Anderson
+	Role: Technical Director & Enterprise Solutions Architect
+	Contact: brian [at] briananderson.xyz
+	Site: https://briananderson.xyz
+	From: United States
+
+/* THANKS */
+	Everyone who reviewed the site along the way.
+
+/* SITE */
+	Last update: 2026/07/01
+	Language: English
+	Doctype: HTML5
+	Standards: HTML5, ARIA, Schema.org JSON-LD
+	Components: SvelteKit 2, Svelte 5, Tailwind CSS
+	Software: mdsvex, Google Cloud Run, Google Cloud Storage, Cloudflare


### PR DESCRIPTION
## Summary

Wave 2 of the site audit — the **AI-readability & SEO** batch. **Stacked on #52** (base = `audit/wave-1-critical-fixes`); retarget to `main` once #52 merges. Same rigor as wave 1: parallel workers, independent review, and the build gate caught real defects across five iterations before this passed.

## What changed

**AI affordances (make the site machine-consumable)**
- **Markdown mirrors** of every content page — `/blog/<slug>.md`, `/projects/<slug>.md` — plus a generated `/resume.md` and a `/llms-full.txt` that concatenates the whole site (resume + all posts + all projects) for single-fetch agent consumption.
- **`llms.txt` "Agent API" section** documenting the live `/chat` and `/fit-finder` endpoints with request/response shapes verified against the functions source (including the `{ analysis: {...} }` fit-finder wrapper), and links to the new mirrors, `resume.json` variants, and `content-index.json`.
- `humans.txt` and `.well-known/security.txt`.

**SEO / structured data**
- `BlogPosting` + `BreadcrumbList` on blog pages, `CreativeWork` + `BreadcrumbList` on projects, `WebSite` schema site-wide.
- Absolute, trailing-slash-consistent canonicals; default `og:image`/`twitter:image`; homepage title carries the role + `jobTitle` in JSON-LD.
- `sitemap.xml` gains `/interests/`, `/following/`, and per-URL `lastmod`; `robots.txt` consolidated to one `User-agent: *` group (AI crawlers still allowed, `/api/` still disallowed); `rss.xml` self-link + language.

**Also**
- Functions error middleware honors `err.status` (413 no longer masked as 500 — the wave-1 follow-up).
- Three content copy fixes (interests typo, GFS adoption-stat phrasing, project heading).

## Verification
- `pnpm build` succeeds; all 20 acceptance criteria confirmed against `build/` output (mirrors + HTML coexist, JSON-LD/canonicals/og:image/sitemap/robots/rss present, `resume.md` + `llms-full.txt` include every section incl. contact). `svelte-check` 0 errors; functions `tsc` clean.
- Review caught and fixed 2 HIGH correctness bugs (generator dropped resume sections; `/fit-finder` docs had the wrong response shape) + a MEDIUM (missing contact info); re-reviewed clean.

## Follow-ups (non-blocking, tracked)
- Confirm production `Content-Type: text/markdown` for the `.md` routes (GCS rsync sets type from its own mimetype table).
- Add generator unit tests (would have caught the dropped-section bugs).
- Dedicated ~1200×630 social-card image instead of the 1.28 MB headshot.

> `site/src/lib/components/Navbar.svelte` (pre-existing uncommitted change) was deliberately excluded.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp