### PR TITLE
fix(ci): portable functions test glob (unblocks deploy)

### DIFF
--- a/site/functions/package.json
+++ b/site/functions/package.json
@@ -5,7 +5,7 @@
     "build": "tsc",
     "dev": "node --env-file-if-exists=.env.local lib/server.js",
     "dev:fitfinder": "FUNCTION_TARGET=fitfinder node --env-file-if-exists=.env.local lib/server.js",
-    "test": "pnpm run build && node --test lib/**/*.test.js"
+    "test": "pnpm run build && node --test lib/*.test.js"
   },
   "engines": {
     "node": "22"


### PR DESCRIPTION
## Problem

The `Test functions` step added in #52 failed on `main`, skipping every deploy job (nothing reached dev):

```
Could not find '.../site/functions/lib/**/*.test.js'
```

CI's bash has no `globstar` and Node 20's `--test` doesn't expand glob patterns natively (that's Node 21+), so the literal `lib/**/*.test.js` reached `node --test`. It passed locally only because the dev machine runs Node 24.

## Fix

`lib/**/*.test.js` → `lib/*.test.js` — plain shell `*` expansion, independent of Node/shell version, matching the compiled test at `lib/security.test.js`.

Verified locally under bash: `lib/*.test.js` → `lib/security.test.js`, 34/34 tests pass.

## Follow-up (pre-existing, not in this PR)
The functions package pins `engines.node: 22` but the `build-functions` CI job uses Node 20 (hence the engine warning, and the reason native `**` globbing wasn't available). Aligning CI to Node 22 would also match the prod Dockerfile.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp