### PR TITLE
fix(ci): declare protobufjs build policy (unblocks container build)

### DIFF
--- a/site/functions/package.json
+++ b/site/functions/package.json
@@ -10,6 +10,11 @@
   "engines": {
     "node": "22"
   },
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "protobufjs"
+    ]
+  },
   "main": "lib/server.js",
   "dependencies": {
     "@google/genai": "^1.0.0",


### PR DESCRIPTION
## Problem

With #54's test-glob fix in place, the pipeline reached the functions **container build**, which then failed:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: protobufjs@7.5.4
process "/bin/sh -c pnpm install --frozen-lockfile" did not complete successfully: exit code: 1
```

The Dockerfile installs pnpm unpinned (`npm install -g pnpm` → v10). pnpm 10 under `CI=true` escalates an **unapproved dependency build script** to a fatal error, whereas CI's pnpm 9 (and local dev) only warn. `protobufjs` is transitive via `@google/genai`; its postinstall has never run for this app, so runtime is unaffected.

## Fix

Declare the policy explicitly with `pnpm.ignoredBuiltDependencies: ["protobufjs"]` so there are no "ignored" builds to escalate. Version-agnostic (pnpm 9 ignores the field), package.json-only (lockfile unchanged).

Verified locally in a clean store under `CI=true`: `pnpm install --frozen-lockfile` no longer reports ignored build scripts, and the lockfile stays up to date.

## Follow-up (pre-existing, not in this PR)
Standardize pnpm across the pipeline — the Dockerfile's unpinned `npm install -g pnpm` and the Node 20 (CI) vs 22 (engines/Dockerfile) drift are what let this pnpm-major-bump behavior change slip in. Pinning pnpm + Node would prevent the next occurrence.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp