### PR TITLE
fix(ci): pin Docker pnpm to v9 (fixes functions container build)

### DIFF
--- a/site/functions/Dockerfile
+++ b/site/functions/Dockerfile
@@ -2,8 +2,10 @@ FROM node:22-slim
 
 WORKDIR /app
 
-# Install pnpm
-RUN npm install -g pnpm
+# Install pnpm — pinned to v9 to match CI (pnpm/action-setup version: 9).
+# Unpinned `npm install -g pnpm` pulls the latest major (v10), which under
+# CI=true fatally errors on unapproved dependency build scripts (protobufjs).
+RUN npm install -g pnpm@9
 
 # Copy package files and install dependencies
 COPY package.json pnpm-lock.yaml ./

--- a/site/functions/package.json
+++ b/site/functions/package.json
@@ -10,11 +10,6 @@
   "engines": {
     "node": "22"
   },
-  "pnpm": {
-    "ignoredBuiltDependencies": [
-      "protobufjs"
-    ]
-  },
   "main": "lib/server.js",
   "dependencies": {
     "@google/genai": "^1.0.0",


### PR DESCRIPTION
## Problem

The functions **container build** failed on `pnpm install --frozen-lockfile`:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: protobufjs@7.5.4
```

The Dockerfile installed pnpm unpinned (`npm install -g pnpm` → v10). pnpm 10 under `CI=true` fatally errors on unapproved dependency build scripts. The `pnpm.ignoredBuiltDependencies` field attempted in #55 had no effect in that pnpm build (and was misleading), so it's removed here.

## Fix

Pin the Dockerfile to `pnpm@9`, matching CI's `pnpm/action-setup` (version: 9).

**Verified with a real local `docker build` (CI=true):** frozen install completes on pnpm 9.15.9, runs protobufjs's postinstall without error, accepts the existing lockfile, and `tsc` builds — image exports successfully. This is the exact step that failed in CI, reproduced-and-fixed locally.

## Follow-up (pre-existing)
Node 20 (CI `build-functions` job) vs 22 (`engines`/Dockerfile) still drift. Standardizing Node and keeping pnpm pinned would fully close this class of pipeline breakage.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp