### PR TITLE
content: builder-first personal bio + mission (voice refresh)

### DIFF
--- a/site/content/personal.yaml
+++ b/site/content/personal.yaml
@@ -2,34 +2,33 @@ name: Brian Anderson
 location: Denver, CO
 
 interests:
-  - name: Automation & Tooling
-    description: Building tools that automate away repetitive tasks
-    passion: I love discovering workflows that can be automated and creating solutions that free people to focus on creative work
+  - name: Building & Shipping
+    description: Turning ideas into working products, usually on nights and weekends
+    passion: I'd rather ship a rough thing that's real than polish a plan that isn't. Most of what I learn comes from getting something in front of people and watching what breaks.
 
-  - name: Building & Creating
-    description: Always working on side projects, from electronics to software
-    passion: There's something magical about taking an idea from concept to reality
+  - name: Agentic AI, done well
+    description: Building AI systems that show their work, and helping teams adopt AI the right way
+    passion: AI drops probabilistic behavior into deterministic systems, which is powerful and easy to get wrong. I spend my time on the guardrails (evals, verification, provenance) that make agent work something you can actually check, and on the best practices and efficiency that help teams turn AI into real leverage instead of noise.
 
-  - name: Mentoring & Teaching
-    description: Sharing knowledge through blog posts, mentoring junior developers
-    passion: Watching someone have that "aha" moment when a concept clicks
-
-  - name: Continuous Learning
-    description: Exploring new technologies, staying current with industry trends
-    passion: Technology moves fast, and I love staying on the cutting edge
+  - name: Automation & Developer Tooling
+    description: Removing the repetitive parts of building software so the creative parts get more room
+    passion: If I do something twice, I start wondering how to make it run itself. The best tools disappear and just leave you faster.
 
 values:
-  - "Quality over speed - do it right the first time"
-  - "Collaboration over competition - we rise by lifting others"
-  - "Practical innovation - solve real problems, not hypothetical ones"
-  - "Transparency - honest communication builds trust"
+  - "Show the work: evidence over assertion, in code and in life"
+  - "Ship it, then harden: real feedback beats a perfect plan"
+  - "Lift others: the best engineers make the people around them better"
+  - "Be honest, especially when it costs something"
 
 hobbies:
-  - name: Electronics & Hardware
-    details: Tinkering with Arduino, building custom IoT devices, home automation projects
+  - name: Family
+    details: Dad first. Everything else is secondary.
 
-  - name: Open Source
-    details: Contributing to projects I use, maintaining my own tools, supporting the community
+  - name: Disc golf
+    details: My reset button. Outdoors, competitive enough to matter, social enough to be fun.
 
-  - name: Cooking
-    details: Weekend meal prep experiments, trying new recipes, perfecting coffee brewing
+  - name: Live music
+    details: Concerts whenever I can. Denver is a good town for it.
+
+  - name: Travel, food & friends
+    details: What recharges me when I'm not in front of a screen.

--- a/site/content/resume.yaml
+++ b/site/content/resume.yaml
@@ -3,21 +3,21 @@ jobTitles:
   - AI Systems Architect
   - Enterprise Solutions Architect
 tagline: Enterprise architect focused on AI platform strategy, cloud modernization, and developer productivity at Fortune 500 scale.
-mission: Driving measurable business automation and customer outcomes through Agentic AI and Cloud Native strategies.
+mission: A builder who happens to work at enterprise scale. By day I shape AI and cloud strategy at AWS; nights and weekends I ship my own products and agent tooling. I care most about the guardrails that make AI something you can actually trust, and the practices that help teams build with it efficiently.
 email: brian@briananderson.xyz
 location: Denver, CO
 summary: >
-  With sixteen years of experience, including twelve in leadership roles, I operate at the intersection
-  of architecture, platform strategy, and enterprise transformation. I design the operating models
-  and technical foundations that enable large organizations to deliver software reliably at scale,
-  covering CI/CD platforms, cloud architectures, and zero-downtime migration strategies across
-  Fortune 500 environments. My work focuses on standardizing delivery, reducing systemic risk, and
-  creating leverage through platform thinking, with deep expertise in microservices and
-  observability-driven systems. I view AI as the next evolution of automation, one that introduces
-  probabilistic behavior into deterministic systems and therefore requires even stronger
-  architectural guardrails. At AWS, I partner with enterprise leaders to define AI strategy,
-  validate high-impact use cases through rapid prototyping, and establish the engineering and
-  operational foundations required to scale these systems into production.
+  I'm a builder at heart who works at enterprise scale. Over sixteen years, twelve of them in
+  leadership, I've designed the CI/CD platforms, cloud architectures, and zero-downtime migrations
+  that let Fortune 500 organizations ship software reliably. My work centers on standardizing
+  delivery, reducing systemic risk, and creating leverage through platform thinking, with deep
+  expertise in microservices and observability-driven systems. I view AI as the next evolution of
+  automation: it introduces probabilistic behavior into deterministic systems and therefore needs
+  even stronger architectural guardrails, along with the practices that let teams adopt it
+  efficiently. That same instinct runs through my nights and weekends, where I ship my own products
+  and agent tooling. At AWS, I partner with enterprise leaders to define AI strategy, validate
+  high-impact use cases through rapid prototyping, and build the engineering and operational
+  foundations required to scale these systems into production.
 skills:
   Cloud & Infrastructure:
     - name: AWS


### PR DESCRIPTION
## Summary

Rewrites the personal-brand copy in Brian's actual voice, per a voice pass. Content-only (two YAML files); no code.

**`personal.yaml`** (feeds `llms.txt`, so this is what AI assistants quote):
- Removed template boilerplate ("there's something magical about taking an idea from concept to reality", "staying on the cutting edge").
- Real hobbies from `interests.yaml` (family-first, disc golf, live music, travel) — the two files no longer contradict; this becomes the single source of truth.
- Builder-first interests and values ("Show the work", "Ship it, then harden", "Be honest, especially when it costs something").

**`resume.yaml`**:
- Mission line: buzzwordy → builder-first ("A builder who happens to work at enterprise scale...").
- Summary reordered to lead with the builder identity while keeping the Fortune 500 weight.
- Both add the "help teams build with AI efficiently" angle alongside the guardrails thesis.

No em dashes, per preference.

## Verification
- YAML valid; `pnpm run build` passes.
- Built `llms.txt` no longer contains any old boilerplate; new voice present in `llms.txt`, `resume.md`, `llms-full.txt`, and the resume page.

## Notes
- Held per your call: no "Founder, Kontour AI" entry and no Kontour project page.
- Out of scope (pre-existing): a numeric range "8–9 deployments/day" in an experience bullet uses an en dash (correct for a range) — left as-is; say the word if you want it normalized.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp