### PR TITLE
ci: harden PR validation gate (real type check, no lockfile fallback)

### DIFF
--- a/.github/workflows/validate-ui.yml
+++ b/.github/workflows/validate-ui.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: site
-        run: pnpm i --frozen-lockfile || pnpm i
+        run: pnpm i --frozen-lockfile
 
       - name: Install Playwright browsers
         working-directory: site
@@ -53,7 +53,7 @@ jobs:
 
       - name: Run TypeScript check
         working-directory: site
-        run: pnpm run check || echo "TypeScript check failed (ignoring third-party posthog-node express type error)"
+        run: pnpm run check
 
       - name: Build site
         working-directory: site


### PR DESCRIPTION
Hygiene cleanup on the **PR validation gate** (`validate-ui.yml`). Deliberately scoped to *not* touch `build-and-deploy.yml`, so the prod deploy path is unchanged.

## Two masks removed
1. **TypeScript check was swallowed.** `pnpm run check || echo "TypeScript check failed (ignoring third-party posthog-node express type error)"` passed the step no matter what. The posthog-node type error it was written for is gone — `pnpm run check` now exits **0** — so the mask only served to hide any *future* type regression. Restored to a real gate.
2. **Frozen-lockfile fallback.** `pnpm i --frozen-lockfile || pnpm i` silently fell back to a non-frozen install whenever the lockfile drifted, defeating the point of `--frozen-lockfile` in CI. Verified `pnpm i --frozen-lockfile` passes cleanly today, so CI can fail loud on a stale lockfile instead.

## Verified locally
- `pnpm run check` → exit 0 (0 errors, 1 benign warning)
- `pnpm i --frozen-lockfile` → exit 0 (lockfile in sync)

This PR's own `validate-ui` run is the proof the hardened gate passes.

## Deliberately NOT included (flagged for a considered follow-up)
- The same `|| pnpm i` fallback still exists in `build-and-deploy.yml` (5 spots). Removing it touches the prod deploy path, so it should be done as its own change and verified on dev *before* a prod promotion — not bundled here.
- Node version drift: CI uses Node 20, the functions Dockerfile uses Node 22. Minor (separate artifacts), worth aligning eventually.
- No `packageManager` field pins pnpm; adding `pnpm@9.x` would keep local (currently v10) and CI (v9) from drifting the lockfile.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp