### PR TITLE
ci: drop lockfile fallback in deploy pipeline (fail loud on drift)

### DIFF
--- a/.github/workflows/ai-evals.yml
+++ b/.github/workflows/ai-evals.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: site
-        run: pnpm i --frozen-lockfile || pnpm i
+        run: pnpm i --frozen-lockfile
 
       - name: Resolve AI eval target
         id: target

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -43,7 +43,7 @@ jobs:
           cache-dependency-path: site/pnpm-lock.yaml
       - name: Install deps
         working-directory: site
-        run: pnpm i --frozen-lockfile || pnpm i
+        run: pnpm i --frozen-lockfile
       - name: Create .env file (Prod for validation)
         working-directory: site
         run: |
@@ -102,7 +102,7 @@ jobs:
           cache-dependency-path: site/pnpm-lock.yaml
       - name: Install functions deps
         working-directory: site/functions
-        run: pnpm i --frozen-lockfile || pnpm i
+        run: pnpm i --frozen-lockfile
       - name: Build functions
         working-directory: site/functions
         run: pnpm run build
@@ -308,7 +308,7 @@ jobs:
           cache-dependency-path: site/pnpm-lock.yaml
       - name: Install deps
         working-directory: site
-        run: pnpm i --frozen-lockfile || pnpm i
+        run: pnpm i --frozen-lockfile
       - name: Install Playwright browsers
         working-directory: site
         run: pnpm exec playwright install chromium
@@ -463,7 +463,7 @@ jobs:
           cache-dependency-path: site/pnpm-lock.yaml
       - name: Install deps
         working-directory: site
-        run: pnpm i --frozen-lockfile || pnpm i
+        run: pnpm i --frozen-lockfile
       - name: Install Playwright browsers
         working-directory: site
         run: pnpm exec playwright install chromium


### PR DESCRIPTION
Follow-up to #60, now on the **deploy pipeline**. Removes the `pnpm i --frozen-lockfile || pnpm i` fallback from every install step:
- `build-and-deploy.yml` — 4 steps (site + site/functions, across dev and prod jobs)
- `ai-evals.yml` — 1 step

The `|| pnpm i` silently fell back to a non-frozen install whenever the lockfile drifted — reinstalling from an unpinned resolution in the exact pipeline that ships to prod. Now CI fails loud on a stale lockfile instead.

## Verified safe before touching the prod path
Ran `pnpm i --frozen-lockfile` under **pnpm 9.15.9** (what `pnpm/action-setup@v4 version: 9` resolves to in CI), for both package roots:
- `site` → exit **0**
- `site/functions` → exit **0**

So the current lockfiles are in sync under CI's pnpm; this change won't break the next deploy. **This PR's merge to `main` triggers the dev deploy — that green run is the end-to-end proof.** Prod stays gated behind manual `workflow_dispatch`.

## Note on the "Node drift" from #60
Not actually drift: `site/functions` declares `engines.node = 22` and the Dockerfile uses `node:22-slim` to match. The site building on Node 20 while functions build on Node 22 is intentional per-artifact. No change needed.

## Still deferred (optional)
A `packageManager` pin (`pnpm@9.15.9`) would keep local (pnpm 10) and CI (pnpm 9) from ever drifting the lockfile. Left out here because it can nag standalone pnpm-10 users locally; worth doing if you adopt corepack.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp