### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ai-evals.yml
+++ b/.github/workflows/ai-evals.yml
@@ -35,15 +35,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "pnpm"
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload AI eval report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ai-eval-report-manual
           path: site/artifacts/ai-evals-manual.json

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -32,11 +32,11 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'
@@ -91,11 +91,11 @@ jobs:
     outputs:
       image: ${{ steps.build.outputs.image }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'
@@ -109,11 +109,11 @@ jobs:
       - name: Test functions
         working-directory: site/functions
         run: pnpm test
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
       - name: Docker auth
         run: gcloud auth configure-docker ${{ secrets.GCP_REGION }}-docker.pkg.dev
       - name: Build and push container
@@ -135,11 +135,11 @@ jobs:
     needs: build-functions
     environment: dev
     steps:
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
       - name: Deploy chat-dev
         env:
           REGION: ${{ secrets.GCP_REGION }}
@@ -215,11 +215,11 @@ jobs:
     environment: prod
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_prod == 'true'
     steps:
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
       - name: Deploy chat (prod)
         env:
           REGION: ${{ secrets.GCP_REGION }}
@@ -297,11 +297,11 @@ jobs:
       image_digest: ${{ needs.build-functions.outputs.digest }}
     if: github.event.inputs.rollback != 'true'
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'
@@ -322,11 +322,11 @@ jobs:
       - name: Build for Dev
         working-directory: site
         run: pnpm run build
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
       - name: Get last successful dev deployment
         id: last_successful
         run: |
@@ -403,7 +403,7 @@ jobs:
         run: pnpm run test:ai:evals
       - name: Upload dev build artifact (Verified)
         if: steps.smoke.outcome == 'success' && steps.smoke_api.outcome == 'success' && steps.ai_evals.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifact-dev
           path: site/build/
@@ -452,11 +452,11 @@ jobs:
     environment: prod
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_prod == 'true'
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'
@@ -480,11 +480,11 @@ jobs:
           rm -rf .svelte-kit .vite
           touch src/routes/+layout.svelte
           pnpm run build
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
       - name: Get last successful prod deployment
         id: last_successful
         run: |
@@ -554,7 +554,7 @@ jobs:
         run: pnpm run test:api
       - name: Upload prod build artifact (Verified)
         if: steps.smoke.outcome == 'success' && steps.smoke_api.outcome == 'success'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifact-prod
           path: site/build/
@@ -608,11 +608,11 @@ jobs:
     if: github.event.inputs.rollback == 'true'
     environment: ${{ github.event.inputs.target_env }}
     steps:
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
       - name: Rollback Cloud Run services
         env:
           REGION: ${{ secrets.GCP_REGION }}
@@ -644,7 +644,7 @@ jobs:
             --no-traffic
           gcloud run services update-traffic $FIT_SERVICE --region "$REGION" --to-latest
           echo "Cloud Run rollback complete."
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Get last successful deployment
         id: last_successful
         run: |
@@ -681,11 +681,11 @@ jobs:
         run: |
           echo "Files in site/build/:"
           find site/build -type f | wc -l
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
       - name: Rollback to ${{ github.event.inputs.target_env }}
         run: |
           BUCKET="dev.briananderson.xyz"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -18,7 +18,7 @@ jobs:
     env:
       TF_IN_AUTOMATION: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Fetch PR Plan Artifact
         id: fetch-plan
@@ -38,7 +38,7 @@ jobs:
           echo "✅ Downloaded plan from run $RUN_ID"
 
       - name: Authenticate to Google Cloud (WIF)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
@@ -65,7 +65,7 @@ jobs:
           terraform apply -auto-approve tfplan.out
 
       - name: Upload Applied Plan
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: terraform-plan-applied
           path: infra/terraform/tfplan.out

--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -22,10 +22,10 @@ jobs:
     env:
       TF_IN_AUTOMATION: "true"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Authenticate to Google Cloud (WIF)
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
@@ -71,7 +71,7 @@ jobs:
         run: terraform show -no-color tfplan.out
 
       - name: Upload Plan
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: terraform-plan
           path: infra/terraform/tfplan.out

--- a/.github/workflows/validate-ui.yml
+++ b/.github/workflows/validate-ui.yml
@@ -18,15 +18,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: 'pnpm'
@@ -82,7 +82,7 @@ jobs:
 
       - name: Upload AI eval report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ai-eval-report
           path: site/artifacts/ai-evals-pr.json
@@ -90,7 +90,7 @@ jobs:
           retention-days: 7
 
       - name: Upload build output
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: build-output
           path: site/build/


### PR DESCRIPTION
Resolves the Node 20 deprecation warnings surfaced in the deploy logs (GitHub is force-running these actions on Node 24 and warning that Node 20 is going away on runners).

## Bumps (to majors targeting Node 24)
| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-node | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| pnpm/action-setup | v4 | v6 |
| google-github-actions/auth | v2 | v3 |
| google-github-actions/setup-gcloud | v2 | v3 |

Standard usage is unchanged across these majors (checkout defaults, setup-node `version`+`cache`, pnpm `version: 9`, artifact `name`/`path`/`retention-days`). `hashicorp/setup-terraform` and `anthropics/claude-code-action` were **not** in the deprecation warning and are left as-is.

## Verification plan
- `claude-review` on this PR exercises `checkout@v5`.
- I'll **dispatch `validate-ui`** on this branch to exercise `checkout@v5` + `setup-node@v6` + `pnpm/action-setup@v6` + `upload-artifact@v7` together.
- Merging triggers the **dev deploy**, which exercises the full set including `auth@v3` + `setup-gcloud@v3` on the deploy path. That green run is the end-to-end proof. Prod stays gated behind manual `workflow_dispatch`.

Only remaining gap: the terraform workflows' `auth@v3`/`setup-gcloud@v3` won't run until a terraform change touches them (path-filtered), so they're bumped but not exercised by this PR.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp