### PR TITLE
content(blog): add ProveIT and agent-provenance posts

### DIFF
--- a/site/content/blog/make-agents-prove-their-facts.md
+++ b/site/content/blog/make-agents-prove-their-facts.md
@@ -1,0 +1,44 @@
+---
+title: Don't trust your agents. Make them prove it.
+date: 2026-06-18
+summary: "The through-line in everything I build right now: you do not trust an agent because it sounds right, you build the system that makes it show its work. What that looks like in practice, from a kids-camp directory to enterprise AI."
+tags: ["AgenticAI", "DataProvenance", "Trust", "Evals", "Builder"]
+keywords: ["provenance", "agent-verification", "evals", "trust-review", "guardrails", "campfit"]
+showTableOfContents: true
+---
+
+Here is the uncomfortable thing about agentic AI: you are dropping probabilistic behavior into systems that used to be deterministic. That is exactly what makes it powerful, and exactly what makes it easy to get wrong. A model that is right 95% of the time feels amazing in a demo and is a liability in production, because the 5% arrives without a warning label.
+
+So the question I keep asking, on every project, is not "is the agent smart enough?" It is "how do I know when it is wrong, before it costs me?"
+
+The answer is almost never "trust it more." It is "make it prove its work."
+
+## A directory taught me this better than any platform
+
+I build a lot of infrastructure. But the project that made this concrete was small and personal: [CampFit](/projects/campfit/), a directory that helps Denver parents find and compare kids' camps.
+
+The fun story is that AI helped me assemble a working app in a weekend. Nobody should care about that. The story I actually care about is what sits underneath it.
+
+Camp information lives in hundreds of inconsistent websites, PDFs, and registration portals. An agent can crawl and extract all of it in an afternoon. But a parent is about to plan their summer and spend real money around what my app tells them. If the agent got a registration date wrong, that is not a bug report, that is a kid who missed a camp.
+
+So nothing a crawler finds is shown to a parent until it earns it. Every value flows through the same pipeline: **crawl, extract, propose, human review, approved claim.** Each fact carries a trust signal that explains *why* it should be believed, when it was checked, and where it came from. The review workbench, the part that decides which AI-gathered data is trustworthy enough to show, is the actual product. The pretty front end is just what is left over once you trust the data.
+
+## It is the same move at enterprise scale
+
+This is not a hobby-project idea. It is the same move I make in my day job shaping AI and cloud strategy, just with more zeros attached.
+
+When a team wants to put an agent into a real workflow, the failure mode is never "the model cannot do it." It is "the model does it, confidently, and nobody can tell the good runs from the bad ones." The fix is the same set of unglamorous machinery every time:
+
+- **Evals**, so "it seems better" becomes a number you can regress against. On my own agent tooling I gate changes with promptfoo so a prompt tweak cannot quietly break three other things.
+- **Provenance**, so every claim can be traced back to its source and its freshness, not just asserted.
+- **Verification loops**, so the system checks its own work against something real before a human relies on it. On the factory floor that meant grounding an agent in actual SOPs instead of letting it improvise a repair procedure.
+
+Different domains, identical shape. The interesting engineering is never the generation. It is the review layer around it.
+
+## Why I think this is the whole game
+
+There is a version of AI adoption that is all velocity and no brakes, and it feels great right up until it doesn't. The teams that win with this stuff are not the ones with the flashiest agents. They are the ones who made it cheap to answer "was that right?" and boring to catch it when it wasn't.
+
+Two of my own values sit under all of this: *show the work, evidence over assertion*, and *be honest, especially when it costs something*. It turns out those are not just personality traits. They are a system design spec. An agent that can show its work is one you can actually deploy. One that just asks to be trusted is a demo.
+
+So I do not build agents I trust. I build systems that make agents prove they were right, and I make that proof the cheapest thing in the stack. Everything good I have shipped lately, from a camp directory to enterprise AI, is some version of that one idea.

--- a/site/content/blog/proveit-industrial-agents.md
+++ b/site/content/blog/proveit-industrial-agents.md
@@ -1,0 +1,48 @@
+---
+title: Agents on the factory floor (ProveIT)
+date: 2026-05-20
+summary: How we turned raw plant telemetry into an agent that flags anomalies, walks operators through fixes, and files the work order. Built for glass and pharma manufacturing, shown in a partner keynote, and then torn apart in a workshop the next day.
+tags: ["AgenticAI", "AWS", "Bedrock", "Manufacturing", "IoT", "Builder"]
+keywords: ["proveit", "industrial-ai", "agentcore", "bedrock", "unified-namespace", "mqtt", "uns", "concept-reply"]
+showTableOfContents: true
+---
+
+Most "AI for manufacturing" demos stop at a dashboard. Someone shows you a chart of sensor data, points at a spike, and says the model noticed it. That is the easy 20%. The hard part, the part that actually changes a shift, is what happens after the spike: who gets told, what they should do about it, and whether the system can take the boring next step on its own.
+
+ProveIT was my attempt to build the whole loop, end to end, for glass and pharma manufacturing.
+
+## The setup
+
+Factories already produce an enormous amount of telemetry. The problem is that it is fragmented across machines, protocols, and vendors, and most of it never reaches anyone who could act on it. So the foundation was not AI at all. It was plumbing.
+
+I pulled plant telemetry over MQTT into a **Unified Namespace**, which is the pattern where every machine, line, and sensor publishes to one consistently structured hierarchy instead of a tangle of point-to-point integrations. From there the streams were categorized, standardized, and landed in a time-series store. Boring on purpose. If the data model is not honest, nothing you build on top of it will be either.
+
+## The agent layer
+
+Once the data was trustworthy, I put an agent layer on top of it using **Bedrock** and **AgentCore**. It did three things:
+
+- **Watched for anomalies** in the live streams, per line and per piece of equipment.
+- **Walked operators through the fix** in natural language, grounded in the actual SOPs, rather than dumping a stack trace and wishing them luck.
+- **Took the next step** when it made sense: filing a work order, pulling up the maintenance procedure, routing the issue to the right persona.
+
+On top of that were persona-specific dashboards, so an operator saw OEE and equipment state the way an operator thinks about them, and you could just ask the system, in plain language, what a production line was doing right now.
+
+The thing I care about is that middle bullet. An anomaly detector that only detects is a smoke alarm. What makes it an agent is that it closes the distance between "something is wrong" and "here is the fix, and I have already started it."
+
+## Keynote, then the workshop
+
+Our partner, **Concept Reply**, featured the demo in a conference keynote and ran it at their booth. That was the flashy day, and it went well.
+
+The day I actually enjoyed was the one after. I ran a workshop that pulled the whole thing apart. Not the polished demo, the build: how the UNS and MQTT ingestion was structured, why we standardized the streams the way we did, how the agent stayed grounded in SOPs instead of hallucinating a procedure, and where the honest limits were. We spent as much time on how we approached the problem as on the result.
+
+That is usually the more valuable session. A keynote convinces people something is possible. A workshop shows them the seams, and the seams are where they learn whether they can build it themselves.
+
+## What I took from it
+
+A few things stuck with me:
+
+- **The data model is the product.** The agent was only as good as the Unified Namespace under it. Almost all of the leverage came from getting the boring foundation right.
+- **"Detect" is not "resolve."** The value was in the last mile, translating a signal into a grounded, SOP-backed action a real person could trust and a system could partly execute.
+- **Grounding beats fluency.** On a factory floor, a confident wrong answer is worse than no answer. Tying the agent to real procedures mattered more than making it sound smart.
+
+ProveIT was a prototype, not a product. But it was the clearest version I have built of the thing I keep coming back to: an agent earns its place not by being impressive, but by doing the next real step and being right about it.

--- a/site/content/blog/taxes-verify-every-number.md
+++ b/site/content/blog/taxes-verify-every-number.md
@@ -1,0 +1,46 @@
+---
+title: A tax workspace that won't trust a number until it's verified
+date: 2026-06-30
+summary: "I built a local-first tool that turns a household's pile of tax paperwork into a checked, source-attributed dataset. The interesting part is not the parsing. It is that nothing gets trusted until it earns it, and every derived number remembers where it came from."
+tags: ["Builder", "DataProvenance", "TypeScript", "MCP", "AgenticAI"]
+keywords: ["taxes", "provenance", "verification", "mcp", "trust", "local-first", "kontourai"]
+showTableOfContents: true
+---
+
+Once a year, every household turns into a small, badly organized data pipeline. W-2s, a stack of 1099s, a 1098, paystubs, last year's return. Some of it arrives twice. Some of it gets corrected after the fact. Somewhere in that pile are the handful of numbers your taxes actually depend on, and the cost of getting one of them wrong is not a stack trace, it is a letter from the IRS.
+
+So I built myself a tax workspace. And the same idea I keep [coming back to](/blog/make-agents-prove-their-facts/) shows up here too: the hard part was never reading the documents. It was deciding which numbers to trust.
+
+## The problem with "just extract the fields"
+
+The naive version of this app is easy. Point a parser at a W-2, pull out the boxes, add them up. I could have shipped that in an afternoon.
+
+It would also be quietly wrong on exactly the cases that matter. You get a corrected W-2 and now two documents disagree. You have three brokerage 1099s and one is a composite that overlaps the others. A paystub says one thing and the official form says another. A tool that just extracts fields will confidently pick one and move on, and you will never know it made a choice.
+
+I did not want a confident tool. I wanted a careful one.
+
+## Facts have to earn their way to trusted
+
+So every value moves through three explicit stages, and they are actually separate things in the system, not just a status flag:
+
+- **Extracted:** the raw number a parser pulled off a document, with its source attached.
+- **Resolved:** the best candidate, chosen by source precedence and confidence when several documents describe the same thing.
+- **Verified:** confirmed, either promoted by the system when it is unambiguous or settled by me when it is not.
+
+The important rule is what the system refuses to do. If a value still has competing candidates, or the winner is only medium-confidence, it is marked as needing verification and it will **not** be promoted to trusted. Ambiguous facts stay visible until someone settles them. The losing candidates do not get deleted either. They stay in the record, so "why did it pick that number?" always has an answer.
+
+Withholding and the downstream analysis are then computed only from verified inputs. The app is allowed to import a mess. It is not allowed to quietly launder that mess into a number you would put on a form.
+
+## Every derived number remembers where it came from
+
+The part I am most happy with is the provenance graph. A derived tax position carries **derivation edges** back to the exact source facts it depends on. Change one of those source facts, say a corrected W-2 supersedes the original, and the system can emit a recompute signal for everything downstream, while keeping the superseded fact in the graph rather than pretending it never existed.
+
+I gave the tax *rules* the same treatment. Standard deductions, brackets, and thresholds are parsed from the official IRS and Colorado source documents, and each value carries citations, a verification status, and a changelog. When a new year's numbers conflict with what is on file, it flags the conflict for review instead of silently overwriting. The rules that decide your taxes should be as auditable as the documents you feed in.
+
+None of this uses an LLM to read your forms, on purpose. Guessing is the one thing you do not want near a tax return. The parsing is deterministic. Where AI comes in is that the whole workspace is exposed as [MCP](https://modelcontextprotocol.io/) tools, so an agent can drive the workflow, and when it does, it operates inside the exact same verification gates a human does. An agent can move things forward. It cannot skip the part where a number has to be verified.
+
+## Same idea, third time
+
+This is a personal, local-first tool. It covers US federal and Colorado, it runs on my own machine against my own documents, and it is nobody's product. I am not going to pretend it saved me a quantified number of hours.
+
+But it runs on the same trust-and-provenance machinery as [CampFit](/projects/campfit/), and it is built on the same conviction as the guardrails work I do at enterprise scale: you do not trust a system because it is confident, you build it so that every number can show its work. A camp directory, a factory floor, a tax return. Different stakes, identical spine.


### PR DESCRIPTION
Fills out the blog (was a single post) with three pieces in your voice, grounded in real work from the repos, no em dashes.

## Posts
1. **"Agents on the factory floor (ProveIT)"** — the industrial agentic-AI build for glass/pharma: Unified Namespace + MQTT → time-series → a Bedrock/AgentCore agent that flags anomalies, walks operators through SOP-grounded fixes, and files the work order. Concept Reply keynote + booth, plus the next-day workshop.
2. **"Don't trust your agents. Make them prove it."** — the trust-and-provenance thesis connecting CampFit's crawl → extract → review pipeline to your enterprise AI guardrails. The through-line piece.
3. **"A tax workspace that won't trust a number until it's verified"** — grounded in the `taxes` repo: a local-first household tax tool with an Extracted → Resolved → Verified gate, a provenance graph where derived numbers trace to their sources, and rule values cited to IRS/CO source docs. Framed honestly: **deterministic parsing (no LLM reading forms)**, exposed to agents via MCP, same `@kontourai/survey` + `surface` trust machinery as CampFit. **No financial data, no prepared-return/CPA-reconciliation detail, no invented metrics** (per your guardrails).

## Verified
All three parse, prerender, and list on `/blog`; `pnpm run build` passes; zero em dashes.

Part 2 of the site-improvement work (part 1 = #64: footer/stat/terminal/hero fixes, merged).

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp