### PR TITLE
ci: key validate-ui concurrency per ref

### DIFF
--- a/.github/workflows/validate-ui.yml
+++ b/.github/workflows/validate-ui.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: validate-ui
+  group: validate-ui-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Small CI fix. The `validate-ui` concurrency group was global, so with two PRs open at once the newer run cancelled the other's in-progress run — which surfaced as a spurious "validate failed (cancelled)" (this happened between PRs #64 and #65 this session).

Keying the group by `github.ref` lets different branches run independently, while a new push to the *same* branch still supersedes its own in-flight run (the useful behavior).

```diff
 concurrency:
-  group: validate-ui
+  group: validate-ui-${{ github.ref }}
   cancel-in-progress: true
```

Workflow-file-only change (path-filtered off `site/**`), so `validate-ui` won't run on this PR; `claude-review` is the gate.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp