### PR TITLE
Wave 2: correctness and rigor (validation, real frontmatter, unit tests)

### DIFF
--- a/.github/workflows/validate-ui.yml
+++ b/.github/workflows/validate-ui.yml
@@ -55,6 +55,10 @@ jobs:
         working-directory: site
         run: pnpm run check
 
+      - name: Run unit tests
+        working-directory: site
+        run: pnpm run test:unit
+
       - name: Build site
         working-directory: site
         run: pnpm run build

--- a/site/package.json
+++ b/site/package.json
@@ -30,6 +30,7 @@
     "test:ai:evals:prod:fit-finder": "AI_EVAL_BASE_URL=https://api.briananderson.xyz AI_EVAL_REPORT_PATH=artifacts/ai-evals-prod-fit-finder.json node scripts/run-ai-evals.js ai-evals/fit-finder.promptfoo.yaml",
     "test:content-index": "tsx scripts/validate-content-index.ts",
     "test:api": "node scripts/validate-api-endpoints.js",
+    "test:unit": "vitest run",
     "test:e2e": "pnpm exec playwright test",
     "test:e2e:chat": "pnpm exec playwright test chat.spec.ts",
     "test:e2e:fit-finder": "pnpm exec playwright test fit-finder.spec.ts",
@@ -62,7 +63,8 @@
     "tsx": "^4.19.2",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.54.0",
-    "vite": "^6.3.0"
+    "vite": "^6.3.0",
+    "vitest": "^4.1.9"
   },
   "dependencies": {
     "clsx": "^2.1.1",

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       vite:
         specifier: ^6.3.0
         version: 6.3.5(@types/node@25.0.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.0.7)(jsdom@29.1.1)(vite@6.3.5(@types/node@25.0.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))
 
 packages:
 
@@ -581,6 +584,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.4':
     resolution: {integrity: sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==}
 
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
@@ -803,6 +809,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@sveltejs/acorn-typescript@1.0.10':
     resolution: {integrity: sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA==}
     peerDependencies:
@@ -859,8 +868,14 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -945,6 +960,35 @@ packages:
     resolution: {integrity: sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1001,6 +1045,10 @@ packages:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
     engines: {node: '>= 0.4'}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   autoprefixer@10.4.21:
     resolution: {integrity: sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1052,6 +1100,10 @@ packages:
   caniuse-lite@1.0.30001733:
     resolution: {integrity: sha512-e4QKw/O2Kavj2VQTKZWrwzkt3IxOmIlU6ajRb6LP64LHpBo1J67k2Hi4Vu/TgJWsNtynurfS0uK3MaUTCPfu5Q==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1081,6 +1133,9 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@0.6.0:
     resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
@@ -1176,6 +1231,9 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
+  es-module-lexer@2.3.0:
+    resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
+
   es6-promise@3.3.1:
     resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
 
@@ -1267,9 +1325,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -1563,6 +1628,9 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
@@ -1650,6 +1718,10 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -1693,6 +1765,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1913,6 +1988,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -1931,6 +2009,12 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -2051,6 +2135,13 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
@@ -2058,6 +2149,10 @@ packages:
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   tldts-core@7.4.5:
     resolution: {integrity: sha512-pGrwzZDvPwKe+7NNUqAunb6rqTfynr0VOUhCMdqbu5xlvNiszsAJygRzwvpVycdzejlbpY+SWJOn+s75Og7FEA==}
@@ -2211,6 +2306,47 @@ packages:
       vite:
         optional: true
 
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
@@ -2233,6 +2369,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -2575,6 +2716,8 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.4': {}
 
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
   '@jridgewell/trace-mapping@0.3.29':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
@@ -2751,6 +2894,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@sveltejs/acorn-typescript@1.0.10(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
@@ -2824,7 +2969,14 @@ snapshots:
   '@tsconfig/node16@1.0.4':
     optional: true
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/cookie@0.6.0': {}
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -2937,6 +3089,47 @@ snapshots:
       '@typescript-eslint/types': 8.54.0
       eslint-visitor-keys: 4.2.1
 
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@6.3.5(@types/node@25.0.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.3.5(@types/node@25.0.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -2984,6 +3177,8 @@ snapshots:
   argparse@2.0.1: {}
 
   aria-query@5.3.1: {}
+
+  assertion-error@2.0.1: {}
 
   autoprefixer@10.4.21(postcss@8.5.6):
     dependencies:
@@ -3033,6 +3228,8 @@ snapshots:
 
   caniuse-lite@1.0.30001733: {}
 
+  chai@6.2.2: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -3065,6 +3262,8 @@ snapshots:
   commander@4.1.1: {}
 
   concat-map@0.0.1: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie@0.6.0: {}
 
@@ -3133,6 +3332,8 @@ snapshots:
   emoji-regex@9.2.2: {}
 
   entities@8.0.0: {}
+
+  es-module-lexer@2.3.0: {}
 
   es6-promise@3.3.1: {}
 
@@ -3296,7 +3497,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   extend-shallow@2.0.1:
     dependencies:
@@ -3574,6 +3781,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   make-error@1.3.6:
     optional: true
 
@@ -3642,6 +3853,8 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  obug@2.1.3: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -3685,6 +3898,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -3897,6 +4112,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   sirv@3.0.1:
@@ -3915,6 +4132,10 @@ snapshots:
   source-map-js@1.2.1: {}
 
   sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -4059,6 +4280,10 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.3)
@@ -4068,6 +4293,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   tldts-core@7.4.5: {}
 
@@ -4198,6 +4425,35 @@ snapshots:
     optionalDependencies:
       vite: 6.3.5(@types/node@25.0.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
 
+  vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.0.7)(jsdom@29.1.1)(vite@6.3.5(@types/node@25.0.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@6.3.5(@types/node@25.0.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.3.0
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.3.5(@types/node@25.0.7)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 25.0.7
+      jsdom: 29.1.1
+    transitivePeerDependencies:
+      - msw
+
   w3c-xmlserializer@5.0.0:
     dependencies:
       xml-name-validator: 5.0.0
@@ -4219,6 +4475,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/site/src/lib/schemas/resume.test.ts
+++ b/site/src/lib/schemas/resume.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { ResumeSchema } from './resume';
+
+const validResume = {
+	name: 'Brian Anderson',
+	jobTitles: ['Engineering Leader', 'Builder'],
+	tagline: 'Builds things that prove their work.',
+	email: 'brian@example.com',
+	location: 'Chicago, IL',
+	summary: 'A summary.',
+	skills: {
+		'Cloud & Infrastructure': [{ name: 'AWS', url: 'https://aws.amazon.com/' }, { name: 'GCP' }]
+	},
+	experience: [
+		{
+			role: 'Principal Engineer',
+			company: 'Acme',
+			location: 'Remote',
+			start_date: 'January 2020',
+			highlights: ['Did a thing', { text: 'Linked thing', link: '/x' }]
+		}
+	],
+	education: [{ school: 'State U', degree: 'BS', location: 'Anytown', start_date: 'September 2010' }],
+	certificates: [
+		{ name: 'AWS SA', url: 'https://aws.amazon.com/certification/', start_date: 'January 2021' }
+	]
+};
+
+describe('ResumeSchema', () => {
+	it('accepts a well-formed resume', () => {
+		const result = ResumeSchema.safeParse(validResume);
+		expect(result.success).toBe(true);
+	});
+
+	it('rejects a resume missing a required field', () => {
+		const missingName: Partial<typeof validResume> = { ...validResume };
+		delete missingName.name;
+		const result = ResumeSchema.safeParse(missingName);
+		expect(result.success).toBe(false);
+	});
+
+	it('rejects a malformed skill entry', () => {
+		const bad = { ...validResume, skills: { Cloud: [{ url: 'https://x.example' }] } };
+		const result = ResumeSchema.safeParse(bad);
+		expect(result.success).toBe(false);
+	});
+});

--- a/site/src/lib/schemas/resume.ts
+++ b/site/src/lib/schemas/resume.ts
@@ -1,81 +1,83 @@
 import { z } from 'zod';
 
-const ResumeHighlightSchema = z.union([
-    z.string(),
-    z.object({
-        text: z.string(),
-        link: z.string().optional(),
-    })
-]);
+// Single source of truth for the resume shape. Types are inferred from these
+// schemas (see the `z.infer` exports below) and re-exported through
+// `$lib/types`, and the server loader validates every YAML variant against
+// `ResumeSchema` at load time. There is deliberately no hand-written duplicate.
 
-export const ResumeSchema = z.object({
-    name: z.string(),
-    title: z.string().optional(),
-    jobTitles: z.array(z.string()),
-    tagline: z.string().optional(),
-    mission: z.string().optional(),
-    email: z.string().email().optional(),
-    location: z.string().optional(),
-    summary: z.string().optional(),
-
-    meta: z.object({
-        order: z.number().int().optional(),
-        schema_version: z.string().optional(),
-    }).optional(),
-
-    skills: z.record(
-        z.string(), // Category name (e.g., "Cloud & Orchestration")
-        z.array(
-            z.union([
-                z.string(),
-                z.object({
-                    name: z.string(),
-                    url: z.string().url().optional(),
-                })
-            ])
-        ).optional()
-    ).optional(),
-
-    experience: z.array(
-        z.object({
-            role: z.string(),
-            company: z.string(),
-            location: z.string().optional(),
-            description: z.string().optional(),
-            highlights: z.array(ResumeHighlightSchema).optional(),
-            start_date: z.string().optional(),
-            end_date: z.string().optional(),
-        })
-    ).optional(),
-
-    'early-career': z.array(
-        z.object({
-            role: z.string(),
-            company: z.string(),
-            location: z.string().optional(),
-            start_date: z.string().optional(),
-            end_date: z.string().optional(),
-        })
-    ).optional(),
-
-    education: z.array(
-        z.object({
-            school: z.string(),
-            degree: z.string(),
-            location: z.string().optional(),
-            start_date: z.string().optional(),
-            end_date: z.string().optional(),
-        })
-    ).optional(),
-
-    certificates: z.array(
-        z.object({
-            name: z.string(),
-            url: z.string().url().optional(),
-            start_date: z.string().optional(),
-            end_date: z.string().optional(),
-        })
-    ).optional(),
+export const ResumeHighlightSchema = z.object({
+	text: z.string(),
+	link: z.string().optional()
 });
 
+export const SkillItemSchema = z.object({
+	name: z.string(),
+	url: z.string().url().optional(),
+	altName: z.string().optional(),
+	resume: z.boolean().optional()
+});
+
+export const ResumeJobSchema = z.object({
+	role: z.string(),
+	company: z.string(),
+	location: z.string(),
+	description: z.string().optional(),
+	highlights: z.array(z.union([z.string(), ResumeHighlightSchema])).default([]),
+	start_date: z.string(),
+	end_date: z.string().optional()
+});
+
+export const ResumeEducationSchema = z.object({
+	school: z.string(),
+	degree: z.string(),
+	location: z.string(),
+	start_date: z.string(),
+	end_date: z.string().optional()
+});
+
+export const ResumeCertificateSchema = z.object({
+	name: z.string(),
+	url: z.string().url().optional(),
+	start_date: z.string(),
+	end_date: z.string().optional()
+});
+
+export const ResumeEarlyCareerSchema = z.object({
+	role: z.string(),
+	company: z.string(),
+	location: z.string(),
+	start_date: z.string(),
+	end_date: z.string().optional()
+});
+
+export const ResumeSchema = z.object({
+	name: z.string(),
+	title: z.string().optional(),
+	jobTitles: z.array(z.string()),
+	tagline: z.string(),
+	mission: z.string().optional(),
+	email: z.string(),
+	location: z.string(),
+	summary: z.string(),
+
+	meta: z
+		.object({
+			order: z.number().int().optional(),
+			schema_version: z.string().optional()
+		})
+		.optional(),
+
+	skills: z.record(z.string(), z.array(SkillItemSchema)),
+	experience: z.array(ResumeJobSchema),
+	'early-career': z.array(ResumeEarlyCareerSchema).optional(),
+	education: z.array(ResumeEducationSchema),
+	certificates: z.array(ResumeCertificateSchema)
+});
+
+export type ResumeHighlight = z.infer<typeof ResumeHighlightSchema>;
+export type SkillItem = z.infer<typeof SkillItemSchema>;
+export type ResumeJob = z.infer<typeof ResumeJobSchema>;
+export type ResumeEducation = z.infer<typeof ResumeEducationSchema>;
+export type ResumeCertificate = z.infer<typeof ResumeCertificateSchema>;
+export type ResumeEarlyCareer = z.infer<typeof ResumeEarlyCareerSchema>;
 export type Resume = z.infer<typeof ResumeSchema>;

--- a/site/src/lib/server/loadResume.ts
+++ b/site/src/lib/server/loadResume.ts
@@ -1,0 +1,20 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import { ResumeSchema, type Resume } from '$lib/schemas/resume';
+
+/**
+ * Read and validate a resume YAML variant from the content directory.
+ *
+ * Parsing goes through `ResumeSchema`, so a missing file or a variant that does
+ * not match the schema throws here and fails the prerender/build. That is
+ * deliberate: a broken or half-populated resume should never ship silently as
+ * an empty page.
+ *
+ * @param file - filename within `content/`, e.g. `resume.yaml` or `resume-ops.yaml`
+ */
+export function loadResume(file: string): Resume {
+	const filePath = path.resolve('content', file);
+	const raw = fs.readFileSync(filePath, 'utf8');
+	return ResumeSchema.parse(yaml.load(raw));
+}

--- a/site/src/lib/server/resumeMarkdown.ts
+++ b/site/src/lib/server/resumeMarkdown.ts
@@ -1,12 +1,9 @@
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
 import type { Resume } from '$lib/types';
+import { loadResume as loadResumeVariant } from './loadResume';
 
+/** Load and validate the default resume variant. */
 export function loadResume(): Resume {
-	const resumePath = path.resolve('content/resume.yaml');
-	const resumeContents = fs.readFileSync(resumePath, 'utf-8');
-	return yaml.load(resumeContents) as Resume;
+	return loadResumeVariant('resume.yaml');
 }
 
 export function buildResumeMarkdown(resume: Resume): string {

--- a/site/src/lib/types.ts
+++ b/site/src/lib/types.ts
@@ -32,72 +32,17 @@ export interface ContentItem {
   route: string;
 }
 
-export interface ResumeHighlight {
-  text: string;
-  link?: string;
-}
-
-export interface ResumeJob {
-  role: string;
-  company: string;
-  location: string;
-  start_date: string;
-  end_date?: string;
-  description?: string;
-  highlights: (string | ResumeHighlight)[];
-}
-
-export interface SkillItem {
-  name: string;
-  resume?: boolean;
-  url?: string;
-  altName?: string;
-}
-
-export type SkillsCategory = Record<string, SkillItem[]>;
-
-export interface ResumeSkillCategory {
-  [category: string]: SkillItem[];
-}
-
-export interface ResumeEducation {
-  school: string;
-  degree: string;
-  start_date: string;
-  end_date?: string;
-  location: string;
-}
-
-export interface ResumeCertificate {
-  name: string;
-  start_date: string;
-  end_date?: string;
-  url?: string;
-}
-
-export interface ResumeEarlyCareer {
-  role: string;
-  company: string;
-  start_date: string;
-  end_date?: string;
-  location: string;
-}
-
-export interface Resume {
-  name: string;
-  title?: string;
-  jobTitles: string[];
-  tagline: string;
-  mission?: string;
-  email: string;
-  location: string;
-  summary: string;
-  skills: ResumeSkillCategory;
-  experience: ResumeJob[];
-  education: ResumeEducation[];
-  certificates: ResumeCertificate[];
-  "early-career"?: ResumeEarlyCareer[];
-}
+// Resume types are inferred from the zod schema (the single source of truth)
+// and re-exported here so existing `$lib/types` imports keep working.
+export type {
+  Resume,
+  ResumeJob,
+  ResumeHighlight,
+  SkillItem,
+  ResumeEducation,
+  ResumeCertificate,
+  ResumeEarlyCareer
+} from '$lib/schemas/resume';
 
 export interface QuickAction {
   id: string;

--- a/site/src/lib/utils/content-loader.ts
+++ b/site/src/lib/utils/content-loader.ts
@@ -1,34 +1,20 @@
 import type { QuickAction, ContentMetadata } from '$lib/types';
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
+import matter from 'gray-matter';
 
 export type { ContentMetadata } from '$lib/types';
 
 const CONTENT_DIR = join(process.cwd(), 'content');
 
 function parseFrontmatter(content: string): ContentMetadata | null {
-	const match = content.match(/^---\n([\s\S]*?)\n---/);
-	if (!match) return null;
-
-	const frontmatter: Record<string, string | string[]> = {};
-	const lines = match[1].split('\n');
-
-	for (const line of lines) {
-		const colonIndex = line.indexOf(':');
-		if (colonIndex > 0) {
-			const key = line.slice(0, colonIndex).trim();
-			const raw = line.slice(colonIndex + 1).trim();
-
-			// Handle array values
-			if (raw.startsWith('[') && raw.endsWith(']')) {
-				frontmatter[key] = raw.slice(1, -1).split(',').map(v => v.trim().replace(/^['"]|['"]$/g, ''));
-			} else {
-				frontmatter[key] = raw;
-			}
-		}
-	}
-
-	return frontmatter as unknown as ContentMetadata;
+	// gray-matter (already used by the content-index build step) is a real YAML
+	// frontmatter parser, so multi-line, nested, quoted, and comma-containing
+	// values all parse correctly instead of tripping the previous line-based
+	// hand parser.
+	const { data } = matter(content);
+	if (!data || Object.keys(data).length === 0) return null;
+	return data as ContentMetadata;
 }
 
 function loadMarkdownFiles(dir: string): QuickAction[] {

--- a/site/src/lib/utils/date.test.ts
+++ b/site/src/lib/utils/date.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { getDuration } from './date';
+
+// Only fixed start+end ranges are asserted; the PRESENT/open-ended branch
+// depends on the current date and is intentionally not pinned here.
+describe('getDuration', () => {
+	it('counts an inclusive span within a single year', () => {
+		// Jan..Mar inclusive = 3 mos
+		expect(getDuration('January 2020', 'March 2020')).toBe('3 mos');
+	});
+
+	it('rolls 12 months up into a year', () => {
+		// Jan 2020..Dec 2020 inclusive = 12 mos -> 1 yr
+		expect(getDuration('January 2020', 'December 2020')).toBe('1 yr');
+	});
+
+	it('formats mixed years and months with pluralization', () => {
+		// Jan 2018..Mar 2020 inclusive = 2 yrs 3 mos
+		expect(getDuration('January 2018', 'March 2020')).toBe('2 yrs 3 mos');
+	});
+
+	it('uses singular yr and mo where appropriate', () => {
+		// Jan 2019..Feb 2020 inclusive = 1 yr 2 mos
+		expect(getDuration('January 2019', 'February 2020')).toBe('1 yr 2 mos');
+	});
+});

--- a/site/src/lib/utils/formatters.test.ts
+++ b/site/src/lib/utils/formatters.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { formatJobTitles } from './formatters';
+
+describe('formatJobTitles', () => {
+	it('returns empty string for no titles', () => {
+		expect(formatJobTitles([])).toBe('');
+		expect(formatJobTitles(undefined as unknown as string[])).toBe('');
+	});
+
+	it('returns the single title unchanged', () => {
+		expect(formatJobTitles(['Engineer'])).toBe('Engineer');
+	});
+
+	it('joins two titles with an ampersand', () => {
+		expect(formatJobTitles(['Engineer', 'Architect'])).toBe('Engineer & Architect');
+	});
+
+	it('comma-separates three or more with an ampersand before the last', () => {
+		expect(formatJobTitles(['A', 'B', 'C'])).toBe('A, B & C');
+		expect(formatJobTitles(['A', 'B', 'C', 'D'])).toBe('A, B, C & D');
+	});
+});

--- a/site/src/lib/utils/sanitize.test.ts
+++ b/site/src/lib/utils/sanitize.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeMarkdown } from './sanitize';
+
+describe('sanitizeMarkdown', () => {
+	it('returns empty string for empty or non-string input', () => {
+		expect(sanitizeMarkdown('')).toBe('');
+		expect(sanitizeMarkdown(null as unknown as string)).toBe('');
+		expect(sanitizeMarkdown(undefined as unknown as string)).toBe('');
+	});
+
+	it('renders basic markdown to HTML', () => {
+		expect(sanitizeMarkdown('**bold**')).toContain('<strong>bold</strong>');
+		expect(sanitizeMarkdown('[link](https://example.com)')).toContain('href="https://example.com"');
+	});
+
+	it('strips script tags', () => {
+		const out = sanitizeMarkdown('hello<script>alert(1)</script>');
+		expect(out).not.toContain('<script');
+		expect(out).toContain('hello');
+	});
+
+	it('removes javascript: URLs', () => {
+		const out = sanitizeMarkdown('[x](javascript:alert(1))');
+		expect(out).not.toContain('javascript:');
+	});
+
+	it('strips inline event handlers', () => {
+		const out = sanitizeMarkdown('<img src=x onerror="alert(1)">');
+		expect(out).not.toContain('onerror');
+	});
+});

--- a/site/src/lib/utils/variantLink.test.ts
+++ b/site/src/lib/utils/variantLink.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import {
+	addVariant,
+	removeVariant,
+	getCanonicalVariantPath,
+	getRedirectTarget,
+	getCanonicalUrl
+} from './variantLink';
+
+describe('addVariant', () => {
+	it('is a no-op for no variant or the default variant', () => {
+		expect(addVariant('/resume', null)).toBe('/resume');
+		expect(addVariant('/resume', undefined)).toBe('/resume');
+		expect(addVariant('/resume', 'default')).toBe('/resume');
+	});
+
+	it('maps canonical home and resume paths to prefix form', () => {
+		expect(addVariant('/', 'ops')).toBe('/ops/');
+		expect(addVariant('/index.html', 'ops')).toBe('/ops/');
+		expect(addVariant('/resume', 'ops')).toBe('/ops/resume/');
+		expect(addVariant('/resume/', 'ops')).toBe('/ops/resume/');
+	});
+
+	it('rewrites homepage hash links to prefix form', () => {
+		expect(addVariant('/#contact', 'ops')).toBe('/ops/#contact');
+	});
+
+	it('uses a query param for other paths and respects existing queries', () => {
+		expect(addVariant('/blog/foo', 'ops')).toBe('/blog/foo?v=ops');
+		expect(addVariant('/blog/foo?x=1', 'ops')).toBe('/blog/foo?x=1&v=ops');
+	});
+
+	it('does not double-append an existing variant query', () => {
+		expect(addVariant('/blog/foo?v=ops', 'ops')).toBe('/blog/foo?v=ops');
+	});
+});
+
+describe('removeVariant', () => {
+	it('strips only the v query param, preserving others and the hash', () => {
+		expect(removeVariant('/blog/foo?v=ops')).toBe('/blog/foo');
+		expect(removeVariant('/blog/foo?x=1&v=ops')).toBe('/blog/foo?x=1');
+		expect(removeVariant('/blog/foo#h')).toBe('/blog/foo#h');
+	});
+});
+
+describe('getCanonicalVariantPath', () => {
+	it('round-trips a prefixed path back to itself', () => {
+		expect(getCanonicalVariantPath('/ops/resume/', 'ops')).toBe('/ops/resume/');
+		expect(getCanonicalVariantPath('/ops', 'ops')).toBe('/ops/');
+	});
+
+	it('strips a static index.html artifact so links do not 404', () => {
+		const out = getCanonicalVariantPath('/blog/index.html/', 'ops');
+		expect(out).not.toContain('index.html');
+		expect(out).toBe('/blog/?v=ops');
+	});
+});
+
+describe('getRedirectTarget', () => {
+	it('redirects generic canonical routes to the prefixed variant', () => {
+		expect(getRedirectTarget('/', 'ops')).toBe('/ops/');
+		expect(getRedirectTarget('/resume', 'ops')).toBe('/ops/resume/');
+	});
+
+	it('returns null for non-canonical routes or no variant', () => {
+		expect(getRedirectTarget('/blog', 'ops')).toBeNull();
+		expect(getRedirectTarget('/', null)).toBeNull();
+		expect(getRedirectTarget('/', 'default')).toBeNull();
+	});
+});
+
+describe('getCanonicalUrl', () => {
+	it('prefixes the production origin', () => {
+		expect(getCanonicalUrl('/resume/')).toBe('https://briananderson.xyz/resume/');
+	});
+});

--- a/site/src/routes/+page.server.ts
+++ b/site/src/routes/+page.server.ts
@@ -1,18 +1,7 @@
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
-import type { Resume } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 
 export const prerender = true;
 
 export const load = async () => {
-  try {
-    const filePath = path.resolve('content/resume.yaml');
-    const fileContents = fs.readFileSync(filePath, 'utf8');
-    const resume = yaml.load(fileContents) as Resume;
-    return { resume };
-  } catch (e) {
-    console.error('Error loading resume.yaml:', e);
-    return { resume: {} as Resume };
-  }
+  return { resume: loadResume('resume.yaml') };
 };

--- a/site/src/routes/builder/+page.server.ts
+++ b/site/src/routes/builder/+page.server.ts
@@ -1,18 +1,7 @@
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
-import type { Resume } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 
 export const prerender = true;
 
 export const load = async () => {
-  try {
-    const filePath = path.resolve('content/resume-builder.yaml');
-    const fileContents = fs.readFileSync(filePath, 'utf8');
-    const resume = yaml.load(fileContents) as Resume;
-    return { resume };
-  } catch (e) {
-    console.error('Error loading resume-builder.yaml:', e);
-    return { resume: {} as Resume };
-  }
+  return { resume: loadResume('resume-builder.yaml') };
 };

--- a/site/src/routes/builder/resume.json/+server.ts
+++ b/site/src/routes/builder/resume.json/+server.ts
@@ -1,14 +1,9 @@
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
-import type { Resume } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 
 export const prerender = true;
 
 export const GET = async () => {
-	const filePath = path.resolve('content/resume-builder.yaml');
-	const fileContents = fs.readFileSync(filePath, 'utf-8');
-	const resume = yaml.load(fileContents) as Resume;
+	const resume = loadResume('resume-builder.yaml');
 
 	const jsonResume = {
 		$schema: 'https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json',

--- a/site/src/routes/builder/resume/+page.server.ts
+++ b/site/src/routes/builder/resume/+page.server.ts
@@ -1,18 +1,7 @@
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
-import type { Resume } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 
 export const prerender = true;
 
 export const load = async () => {
-  try {
-    const filePath = path.resolve('content/resume-builder.yaml');
-    const fileContents = fs.readFileSync(filePath, 'utf8');
-    const resume = yaml.load(fileContents) as Resume;
-    return { resume };
-  } catch (e) {
-    console.error('Error loading resume-builder.yaml:', e);
-    return { resume: {} as Resume };
-  }
+  return { resume: loadResume('resume-builder.yaml') };
 };

--- a/site/src/routes/llms-full.txt/+server.ts
+++ b/site/src/routes/llms-full.txt/+server.ts
@@ -2,7 +2,8 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
 import { PUBLIC_SITE_URL } from '$env/static/public';
-import type { ContentMetadata, Resume } from '$lib/types';
+import type { ContentMetadata } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 import { buildResumeMarkdown } from '$lib/server/resumeMarkdown';
 
 interface Personal {
@@ -14,9 +15,7 @@ interface Personal {
 export const prerender = true;
 
 export const GET = async () => {
-	const resumePath = path.resolve('content/resume.yaml');
-	const resumeContents = fs.readFileSync(resumePath, 'utf-8');
-	const resume = yaml.load(resumeContents) as Resume;
+	const resume = loadResume('resume.yaml');
 
 	const personalPath = path.resolve('content/personal.yaml');
 	const personalContents = fs.readFileSync(personalPath, 'utf-8');

--- a/site/src/routes/llms.txt/+server.ts
+++ b/site/src/routes/llms.txt/+server.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import yaml from 'js-yaml';
 import path from 'path';
 import { PUBLIC_SITE_URL } from '$env/static/public';
-import type { Resume } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 
 interface Personal {
 	interests: { name: string; description: string }[];
@@ -13,9 +13,7 @@ interface Personal {
 export const prerender = true;
 
 export const GET = async () => {
-	const resumePath = path.resolve('content/resume.yaml');
-	const resumeContents = fs.readFileSync(resumePath, 'utf-8');
-	const resume = yaml.load(resumeContents) as Resume;
+	const resume = loadResume('resume.yaml');
 
 	const personalPath = path.resolve('content/personal.yaml');
 	const personalContents = fs.readFileSync(personalPath, 'utf-8');

--- a/site/src/routes/ops/+page.server.ts
+++ b/site/src/routes/ops/+page.server.ts
@@ -1,18 +1,7 @@
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
-import type { Resume } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 
 export const prerender = true;
 
 export const load = async () => {
-  try {
-    const filePath = path.resolve('content/resume-ops.yaml');
-    const fileContents = fs.readFileSync(filePath, 'utf8');
-    const resume = yaml.load(fileContents) as Resume;
-    return { resume };
-  } catch (e) {
-    console.error('Error loading resume-ops.yaml:', e);
-    return { resume: {} as Resume };
-  }
+  return { resume: loadResume('resume-ops.yaml') };
 };

--- a/site/src/routes/ops/resume.json/+server.ts
+++ b/site/src/routes/ops/resume.json/+server.ts
@@ -1,14 +1,9 @@
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
-import type { Resume } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 
 export const prerender = true;
 
 export const GET = async () => {
-	const filePath = path.resolve('content/resume-ops.yaml');
-	const fileContents = fs.readFileSync(filePath, 'utf-8');
-	const resume = yaml.load(fileContents) as Resume;
+	const resume = loadResume('resume-ops.yaml');
 
 	const jsonResume = {
 		$schema: 'https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json',

--- a/site/src/routes/ops/resume/+page.server.ts
+++ b/site/src/routes/ops/resume/+page.server.ts
@@ -1,18 +1,7 @@
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
-import type { Resume } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 
 export const prerender = true;
 
 export const load = async () => {
-  try {
-    const filePath = path.resolve('content/resume-ops.yaml');
-    const fileContents = fs.readFileSync(filePath, 'utf8');
-    const resume = yaml.load(fileContents) as Resume;
-    return { resume };
-  } catch (e) {
-    console.error('Error loading resume-ops.yaml:', e);
-    return { resume: {} as Resume };
-  }
+  return { resume: loadResume('resume-ops.yaml') };
 };

--- a/site/src/routes/resume.json/+server.ts
+++ b/site/src/routes/resume.json/+server.ts
@@ -1,14 +1,9 @@
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
-import type { Resume } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 
 export const prerender = true;
 
 export const GET = async () => {
-	const filePath = path.resolve('content/resume.yaml');
-	const fileContents = fs.readFileSync(filePath, 'utf-8');
-	const resume = yaml.load(fileContents) as Resume;
+	const resume = loadResume('resume.yaml');
 
 	const jsonResume = {
 		$schema: 'https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json',

--- a/site/src/routes/resume/+page.server.ts
+++ b/site/src/routes/resume/+page.server.ts
@@ -1,18 +1,7 @@
-import fs from 'fs';
-import yaml from 'js-yaml';
-import path from 'path';
-import type { Resume } from '$lib/types';
+import { loadResume } from '$lib/server/loadResume';
 
 export const prerender = true;
 
 export const load = async () => {
-  try {
-    const filePath = path.resolve('content/resume.yaml');
-    const fileContents = fs.readFileSync(filePath, 'utf8');
-    const resume = yaml.load(fileContents) as Resume;
-    return { resume };
-  } catch (e) {
-    console.error('Error loading resume.yaml:', e);
-    return { resume: {} as Resume };
-  }
+  return { resume: loadResume('resume.yaml') };
 };

--- a/site/vitest.config.ts
+++ b/site/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+
+// Unit tests for pure logic (utils, schemas). Playwright e2e lives under e2e/
+// and is run separately via `pnpm run test:e2e`.
+export default defineConfig({
+	test: {
+		environment: 'node',
+		include: ['src/**/*.{test,spec}.ts']
+	},
+	resolve: {
+		alias: {
+			$lib: fileURLToPath(new URL('./src/lib', import.meta.url))
+		}
+	}
+});


### PR DESCRIPTION
Architecture-showcase pass, **wave 2 of 4** (correctness + rigor). The highest-signal wave.

## Single source of truth for the resume
- The zod `ResumeSchema` is now the **only** definition. `Resume` and its sub-types (`ResumeJob`, `SkillItem`, `ResumeHighlight`, `ResumeEducation`, ...) are inferred from it and re-exported through `$lib/types`. The hand-written duplicate interface in `types.ts` is deleted, so the two can no longer drift.
- New `$lib/server/loadResume` validates every variant with `ResumeSchema.parse()` at load time. **All 10 resume loaders** (page loaders, `.json` endpoints, `llms.txt`/`llms-full.txt`, `resumeMarkdown`) route through it instead of an unchecked `yaml.load(...) as Resume` + a silent `{} as Resume` fallback. A broken/half-populated resume now fails the build instead of shipping an empty page.

## Real frontmatter parsing
- `content-loader` uses **gray-matter** (already a dependency, already used by the content-index build step) instead of the fragile hand-rolled line parser. Multi-line, nested, quoted, and comma-containing values now parse correctly.

## Unit tests (new)
- Add **vitest** + `test:unit`, wired into the `validate-ui` CI gate.
- **27 tests**: `variantLink` (incl. the `index.html` canonical fix), `date` duration math, job-title formatting, markdown `sanitize` (script / `javascript:` / event-handler stripping), and `ResumeSchema` accept/reject.

## Verification
`check` / `lint` / `test:unit` (27) / `test:resumes` (all 3 variants) / `build` all green. Prerendered `resume.json` verified populated (7 roles, 7 skill categories) — the validated loaders produce correct output end-to-end.

Dev-only; production promotion remains a manual `workflow_dispatch`.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp