### PR TITLE
Wave 3: accessible dialogs + consolidate all modals onto Modal

### DIFF
--- a/site/src/lib/components/KeyboardShortcutsHelp.svelte
+++ b/site/src/lib/components/KeyboardShortcutsHelp.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { type KeyboardShortcut, getShortcutDisplay } from '$lib/hooks/useKeyboardShortcuts';
+	import Modal from './Modal.svelte';
 
 	interface Props {
 		shortcuts: KeyboardShortcut[];
@@ -8,56 +9,37 @@
 	}
 
 	let { shortcuts, visible, onClose }: Props = $props();
-
-	function handleBackdropClick(e: MouseEvent) {
-		if (e.target === e.currentTarget) {
-			onClose();
-		}
-	}
 </script>
 
-{#if visible}
-	<div
-		class="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
-		data-testid="keyboard-help"
-		role="dialog"
-		tabindex="-1"
-		aria-modal="true"
-		aria-labelledby="shortcuts-title"
-		onclick={handleBackdropClick}
-		onkeydown={(e) => e.key === 'Escape' && onClose()}
-	>
-		<div class="bg-terminal-black border-2 border-terminal-green shadow-2xl max-w-2xl w-full mx-4">
-			<div class="flex justify-between items-center px-4 py-2 bg-terminal-green/10 border-b-2 border-terminal-green font-mono text-terminal-green">
-				<span id="shortcuts-title">Keyboard Shortcuts</span>
-				<div class="flex items-center gap-2">
-					<kbd class="px-2 py-0.5 bg-terminal-green/10 border border-terminal-green rounded text-terminal-green font-mono text-xs">Esc</kbd>
-					<button
-						onclick={onClose}
-						class="text-2xl leading-none hover:text-terminal-green transition-colors cursor-pointer"
-						aria-label="Close shortcuts help"
+<Modal
+	{visible}
+	{onClose}
+	title="Keyboard Shortcuts"
+	labelledby="shortcuts-title"
+	closeLabel="Close shortcuts help"
+	testid="keyboard-help"
+>
+	<div class="flex-1 min-h-0 overflow-y-auto p-6 font-mono text-sm">
+		<div class="space-y-4">
+			{#each shortcuts as shortcut}
+				<div class="flex justify-between items-center py-2 border-b border-terminal-green/20">
+					<span class="text-terminal-text">{shortcut.description}</span>
+					<kbd
+						class="px-3 py-1 bg-terminal-green/10 border border-terminal-green rounded text-terminal-green font-mono text-xs"
 					>
-						×
-					</button>
+						{getShortcutDisplay(shortcut)}
+					</kbd>
 				</div>
-			</div>
+			{/each}
+		</div>
 
-			<div class="p-6 max-h-[70vh] overflow-y-auto font-mono text-sm">
-				<div class="space-y-4">
-					{#each shortcuts as shortcut}
-						<div class="flex justify-between items-center py-2 border-b border-terminal-green/20">
-							<span class="text-terminal-text">{shortcut.description}</span>
-							<kbd class="px-3 py-1 bg-terminal-green/10 border border-terminal-green rounded text-terminal-green font-mono text-xs">
-								{getShortcutDisplay(shortcut)}
-							</kbd>
-						</div>
-					{/each}
-				</div>
-
-				<div class="mt-6 text-sm text-terminal-text/70">
-					<p>Press <kbd class="px-2 py-0.5 bg-terminal-green/10 border border-terminal-green rounded text-terminal-green font-mono text-xs">Esc</kbd> or click outside to close this dialog</p>
-				</div>
-			</div>
+		<div class="mt-6 text-sm text-terminal-text/70">
+			<p>
+				Press <kbd
+					class="px-2 py-0.5 bg-terminal-green/10 border border-terminal-green rounded text-terminal-green font-mono text-xs"
+					>Esc</kbd
+				> or click outside to close this dialog
+			</p>
 		</div>
 	</div>
-{/if}
+</Modal>

--- a/site/src/lib/components/Modal.svelte
+++ b/site/src/lib/components/Modal.svelte
@@ -21,6 +21,12 @@
 		 * content up to md:max-h-[90vh]. On mobile it is always full-screen.
 		 */
 		fill?: boolean;
+		/**
+		 * Desktop placement. 'center' is the default dialog placement; 'top' anchors
+		 * the card near the top (for command-palette style modals). Mobile is always
+		 * a full-screen sheet regardless.
+		 */
+		align?: 'center' | 'top';
 		/** Optional extra buttons rendered in the header, left of the × (e.g. "Clear"). */
 		actions?: Snippet;
 		/** Modal body. */
@@ -35,15 +41,22 @@
 		closeLabel = 'Close',
 		testid,
 		fill = false,
+		align = 'center',
 		actions,
 		children
 	}: Props = $props();
+
+	// Elements that can receive keyboard focus, for the focus trap.
+	const FOCUSABLE =
+		'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+	let panel = $state<HTMLElement | null>(null);
 
 	function handleBackdropClick(e: MouseEvent) {
 		if (e.target === e.currentTarget) onClose();
 	}
 
-	// Escape closes, regardless of focus.
+	// Escape closes, regardless of where focus currently sits.
 	$effect(() => {
 		if (visible && browser) {
 			const onKey = (e: KeyboardEvent) => {
@@ -53,26 +66,82 @@
 			return () => window.removeEventListener('keydown', onKey);
 		}
 	});
+
+	// While open: lock body scroll, move focus into the dialog, and restore focus
+	// to the previously focused element on close. This makes every modal that uses
+	// this shell a proper accessible dialog.
+	$effect(() => {
+		if (!visible || !browser) return;
+
+		const restoreFocus = document.activeElement as HTMLElement | null;
+		const prevOverflow = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+
+		const raf = requestAnimationFrame(() => {
+			if (!panel) return;
+			// Respect a child that focused its own control (e.g. a chat input or a
+			// command-palette search box). Otherwise focus a [data-autofocus] target,
+			// then the first focusable, then the panel itself.
+			if (panel.contains(document.activeElement)) return;
+			const target =
+				panel.querySelector<HTMLElement>('[data-autofocus]') ??
+				panel.querySelector<HTMLElement>(FOCUSABLE) ??
+				panel;
+			target?.focus();
+		});
+
+		return () => {
+			cancelAnimationFrame(raf);
+			document.body.style.overflow = prevOverflow;
+			restoreFocus?.focus?.();
+		};
+	});
+
+	// Trap Tab within the dialog so focus cannot escape to the page behind it.
+	function trapTab(e: KeyboardEvent) {
+		if (e.key !== 'Tab' || !panel) return;
+		const nodes = Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+			(el) => el.offsetParent !== null
+		);
+		if (nodes.length === 0) {
+			e.preventDefault();
+			panel.focus();
+			return;
+		}
+		const first = nodes[0];
+		const last = nodes[nodes.length - 1];
+		if (e.shiftKey && document.activeElement === first) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && document.activeElement === last) {
+			e.preventDefault();
+			first.focus();
+		}
+	}
 </script>
 
 {#if visible}
 	<!--
 		Mobile: full-screen sheet anchored to the top, sized with 100dvh so the
 		virtual keyboard shrinks it instead of shoving a centered card off-screen.
-		Desktop (md+): a centered, bordered card.
+		Desktop (md+): a bordered card, centered or top-anchored per `align`.
 	-->
 	<div
-		class="fixed inset-0 z-50 flex flex-col md:items-center md:justify-center bg-black/80 backdrop-blur-sm md:p-4"
+		class="fixed inset-0 z-50 flex flex-col bg-black/80 backdrop-blur-sm md:p-4 {align === 'top'
+			? 'md:items-start md:justify-center md:pt-20'
+			: 'md:items-center md:justify-center'}"
 		role="dialog"
 		aria-modal="true"
 		aria-labelledby={labelledby}
 		tabindex="-1"
 		data-testid={testid}
 		onclick={handleBackdropClick}
-		onkeydown={(e) => e.key === 'Escape' && onClose()}
+		onkeydown={trapTab}
 	>
 		<div
-			class="bg-terminal-black border-terminal-green shadow-2xl w-full h-[100dvh] flex flex-col border-0 md:border-2 md:max-w-4xl {fill
+			bind:this={panel}
+			tabindex="-1"
+			class="bg-terminal-black border-terminal-green shadow-2xl w-full h-[100dvh] flex flex-col border-0 md:border-2 md:max-w-4xl focus:outline-none {fill
 				? 'md:h-[80vh]'
 				: 'md:h-auto md:max-h-[90vh]'}"
 		>

--- a/site/src/lib/components/QuickActions.svelte
+++ b/site/src/lib/components/QuickActions.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { goto } from '$app/navigation';
 	import type { QuickAction } from '$lib/types';
+	import Modal from './Modal.svelte';
 
 	interface Props {
 		visible: boolean;
@@ -73,13 +74,14 @@
 		}
 	});
 
-	// Focus input when visible
+	// Focus input when visible. Modal defers to this (it won't steal focus back).
 	$effect(() => {
 		if (visible && inputElement) {
 			inputElement.focus();
 		}
 	});
 
+	// Arrow/Enter navigation. Escape is owned by the Modal shell.
 	function handleKeyDown(e: KeyboardEvent) {
 		const actions = filteredActions();
 
@@ -92,9 +94,6 @@
 		} else if (e.key === 'Enter') {
 			e.preventDefault();
 			executeAction(actions[selectedIndex]);
-		} else if (e.key === 'Escape') {
-			e.preventDefault();
-			onClose();
 		}
 	}
 
@@ -119,90 +118,65 @@
 		};
 		return labels[category] || category;
 	}
-
-	function handleBackdropClick(e: MouseEvent) {
-		if (e.target === e.currentTarget) {
-			onClose();
-		}
-	}
 </script>
 
-{#if visible}
-	<div
-		class="fixed inset-0 z-50 flex items-start justify-center pt-20 bg-black/80 backdrop-blur-sm"
-		data-testid="quick-actions"
-		role="dialog"
-		tabindex="-1"
-		aria-modal="true"
-		aria-labelledby="quick-actions-title"
-		onclick={handleBackdropClick}
-		onkeydown={handleKeyDown}
-	>
-		<div class="bg-terminal-black border-2 border-terminal-green shadow-2xl max-w-2xl w-full mx-4">
-			<div class="flex justify-between items-center px-4 py-2 bg-terminal-green/10 border-b-2 border-terminal-green font-mono text-terminal-green">
-				<span id="quick-actions-title">Quick Actions</span>
-				<div class="flex items-center gap-1">
-					<span class="text-xs text-terminal-green/70">Esc</span>
+<Modal
+	{visible}
+	{onClose}
+	title="Quick Actions"
+	labelledby="quick-actions-title"
+	closeLabel="Close quick actions"
+	testid="quick-actions"
+	align="top"
+>
+	<div class="font-mono text-sm flex flex-col flex-1 min-h-0">
+		<div class="p-4 border-b border-terminal-green/20 shrink-0">
+			<input
+				bind:this={inputElement}
+				bind:value={searchQuery}
+				onkeydown={handleKeyDown}
+				type="text"
+				placeholder="Type to search..."
+				class="bg-transparent border-none outline-none text-terminal-green placeholder:text-terminal-text/50 w-full"
+				data-testid="quick-actions-input"
+				aria-label="Search actions"
+			/>
+		</div>
+
+		<div class="flex-1 min-h-0 overflow-y-auto">
+			{#if filteredActions().length === 0}
+				<div class="p-8 text-center text-terminal-text/70">
+					No actions found for "{searchQuery}"
+				</div>
+			{:else}
+				{#each filteredActions() as action, index (action.id)}
 					<button
-						onclick={onClose}
-						class="text-2xl leading-none hover:text-terminal-green transition-colors cursor-pointer"
-						aria-label="Close quick actions"
+						onclick={() => executeAction(action)}
+						onmouseenter={() => selectedIndex = index}
+						class="w-full px-4 py-3 flex items-center gap-3 text-left border-b border-terminal-green/10 transition-colors cursor-pointer hover:bg-terminal-green/5 {index === selectedIndex ? 'bg-terminal-green/10' : ''}"
+						data-testid="action-{action.id}"
 					>
-						×
-					</button>
-				</div>
-			</div>
-
-			<div class="font-mono text-sm">
-				<div class="p-4 border-b border-terminal-green/20">
-					<input
-						bind:this={inputElement}
-						bind:value={searchQuery}
-						onkeydown={handleKeyDown}
-						type="text"
-						placeholder="Type to search..."
-						class="bg-transparent border-none outline-none text-terminal-green placeholder:text-terminal-text/50 w-full"
-						data-testid="quick-actions-input"
-						aria-label="Search actions"
-					/>
-				</div>
-
-				<div class="max-h-96 overflow-y-auto">
-					{#if filteredActions().length === 0}
-						<div class="p-8 text-center text-terminal-text/70">
-							No actions found for "{searchQuery}"
+						<div class="flex-1">
+							<div class="flex items-center gap-2">
+								<span class="text-terminal-green font-medium">{action.title}</span>
+								<span class="text-xs text-terminal-text/70 px-2 py-0.5 rounded border border-terminal-green/30">{getCategoryLabel(action.category)}</span>
+							</div>
+							{#if action.description}
+								<div class="text-xs text-terminal-text/70 mt-1">{action.description}</div>
+							{/if}
 						</div>
-					{:else}
-						{#each filteredActions() as action, index}
-							<button
-								onclick={() => executeAction(action)}
-								onmouseenter={() => selectedIndex = index}
-								class="w-full px-4 py-3 flex items-center gap-3 text-left border-b border-terminal-green/10 transition-colors cursor-pointer hover:bg-terminal-green/5 {index === selectedIndex ? 'bg-terminal-green/10' : ''}"
-								data-testid="action-{action.id}"
-							>
-								<div class="flex-1">
-									<div class="flex items-center gap-2">
-										<span class="text-terminal-green font-medium">{action.title}</span>
-										<span class="text-xs text-terminal-text/70 px-2 py-0.5 rounded border border-terminal-green/30">{getCategoryLabel(action.category)}</span>
-									</div>
-									{#if action.description}
-										<div class="text-xs text-terminal-text/70 mt-1">{action.description}</div>
-									{/if}
-								</div>
-								{#if index === selectedIndex}
-									<span class="text-terminal-green text-xs">↵</span>
-								{/if}
-							</button>
-						{/each}
-					{/if}
-				</div>
+						{#if index === selectedIndex}
+							<span class="text-terminal-green text-xs">↵</span>
+						{/if}
+					</button>
+				{/each}
+			{/if}
+		</div>
 
-				<div class="p-3 border-t border-terminal-green/20 text-xs text-terminal-text/70 flex gap-4">
-					<span><kbd class="px-1.5 py-0.5 bg-terminal-green/10 border border-terminal-green/30 rounded text-terminal-green font-mono">↑↓</kbd> Navigate</span>
-					<span><kbd class="px-1.5 py-0.5 bg-terminal-green/10 border border-terminal-green/30 rounded text-terminal-green font-mono">↵</kbd> Select</span>
-					<span><kbd class="px-1.5 py-0.5 bg-terminal-green/10 border border-terminal-green/30 rounded text-terminal-green font-mono">Esc</kbd> Close</span>
-				</div>
-			</div>
+		<div class="p-3 border-t border-terminal-green/20 text-xs text-terminal-text/70 flex gap-4 shrink-0">
+			<span><kbd class="px-1.5 py-0.5 bg-terminal-green/10 border border-terminal-green/30 rounded text-terminal-green font-mono">↑↓</kbd> Navigate</span>
+			<span><kbd class="px-1.5 py-0.5 bg-terminal-green/10 border border-terminal-green/30 rounded text-terminal-green font-mono">↵</kbd> Select</span>
+			<span><kbd class="px-1.5 py-0.5 bg-terminal-green/10 border border-terminal-green/30 rounded text-terminal-green font-mono">Esc</kbd> Close</span>
 		</div>
 	</div>
-{/if}
+</Modal>


### PR DESCRIPTION
Architecture-showcase pass, **wave 3 of 4** (accessibility + modal consolidation).

## Modal is now a proper accessible dialog
One fix upgrades **every** consumer (Chatbot, FitFinder, KeyboardShortcutsHelp, QuickActions):
- **Focus trap** — Tab / Shift+Tab cycle within the dialog, never escaping to the page behind.
- **Focus restoration** — focus returns to the previously focused element on close.
- **Body scroll lock** while open (`overflow: hidden`, restored on close).
- **Gentle auto-focus** — focuses `[data-autofocus]` / first focusable, but yields to a child that already grabbed focus, so the chat input and command-palette search box keep their own autofocus.
- New **`align`** prop: `center` (default) or `top` for command-palette placement.

## Two more dialogs consolidated
- **KeyboardShortcutsHelp** now uses `<Modal>` (was a duplicated backdrop + terminal header).
- **QuickActions** now uses `<Modal align="top">`, keeping its search input + arrow-key nav; Escape is owned by the shell.
- `ExternalLinkModal` (traffic-light confirm) and `Lightbox` (swipe image viewer) intentionally keep their distinct shells.

## Verification
Playwright on desktop (1280x800) + mobile (390x844), **40/40 assertions**: scroll lock (`hidden`→restored), focus trap (zero escapes across repeated Tabs in all 4 modals), focus restored to `body` on Escape, QuickActions top-anchored with input auto-focused and arrow nav working, Chatbot textarea focused on open, mobile full-screen sheets with 44x44 close targets. `check` / `lint` / `build` / `test:unit` all green.

Dev-only; production promotion remains a manual `workflow_dispatch`.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp