### PR TITLE
Wave 4: standardize on Svelte 5 runes across all components and routes

### DIFF
--- a/site/src/lib/components/ExperienceItem.svelte
+++ b/site/src/lib/components/ExperienceItem.svelte
@@ -3,11 +3,15 @@
   import type { ResumeJob } from '$lib/types';
   import '$lib/components/ui/glowing-green.css';
 
-  export let job: ResumeJob;
-  export let compact = false;
+  interface Props {
+    job: ResumeJob;
+    compact?: boolean;
+  }
 
-  function isCurrentJob(job: ResumeJob): boolean {
-    return !job.end_date;
+  let { job, compact = false }: Props = $props();
+
+  function isCurrentJob(j: ResumeJob): boolean {
+    return !j.end_date;
   }
 </script>
 

--- a/site/src/lib/components/Footer.svelte
+++ b/site/src/lib/components/Footer.svelte
@@ -2,7 +2,7 @@
   import { page } from "$app/stores";
   import VariantSwitcher from "$lib/components/VariantSwitcher.svelte";
 
-  $: isError = $page.status >= 400;
+  const isError = $derived($page.status >= 400);
 </script>
 
 <footer

--- a/site/src/lib/components/Homepage.svelte
+++ b/site/src/lib/components/Homepage.svelte
@@ -6,13 +6,17 @@
   import { formatJobTitles } from "$lib/utils/formatters";
   import { addVariant } from "$lib/utils/variantLink";
 
-  export let resume: Resume;
-  export let variant: string | null = null;
-  export let links: Record<string, string> | null = null;
+  interface Props {
+    resume: Resume;
+    variant?: string | null;
+    links?: Record<string, string> | null;
+  }
 
-  const currentJob = resume.experience[0];
+  let { resume, variant = null, links = null }: Props = $props();
 
-  const jsonLd = {
+  const currentJob = $derived(resume.experience[0]);
+
+  const jsonLd = $derived({
     "@context": "https://schema.org",
     "@type": "Person",
     "name": resume.name,
@@ -42,22 +46,23 @@
       "name": currentJob.role,
       "description": currentJob.description
     }
-  };
+  });
 
-  $: generatedLinks = links || {
+  const generatedLinks = $derived(links || {
     resume: addVariant('/resume/', variant),
     projects: addVariant('/projects/', variant),
     blog: addVariant('/blog/', variant)
-  };
+  });
 
-  $: recruiterSummary =
+  const recruiterSummary = $derived(
     variant === "ops"
       ? "I build reliable delivery platforms and observability systems for high-stakes production environments, and I apply that same discipline to AI workloads."
       : variant === "builder"
         ? "I ship production software across the stack and now build agent-driven products with tracing, tool orchestration, and evaluation in mind."
-        : "I help enterprises modernize delivery systems at scale and now bring that same rigor to AI platforms, agent workflows, and developer productivity.";
+        : "I help enterprises modernize delivery systems at scale and now bring that same rigor to AI platforms, agent workflows, and developer productivity."
+  );
 
-  $: proofPoints =
+  const proofPoints = $derived(
     variant === "ops"
       ? [
           "14 mission-critical apps migrated with zero downtime",
@@ -77,10 +82,11 @@
             "New features and responses to customer feedback shipped in 8-9 production deployments per day",
             "90% deployment lead-time reduction & $30M estimated savings",
             "Top 0.03% of 280k+ Amazon Kiro CLI users"
-          ];
+          ]
+  );
 
-  let openCategories: Record<string, boolean> = {};
-  let showAllExperience = false;
+  let openCategories = $state<Record<string, boolean>>({});
+  let showAllExperience = $state(false);
 
   function toggleCategory(category: string) {
     openCategories = {
@@ -89,10 +95,12 @@
     };
   }
 
-  $: formattedTitle = formatJobTitles(resume.jobTitles);
+  const formattedTitle = $derived(formatJobTitles(resume.jobTitles));
 
   // Build JSON-LD tag to avoid ESLint parser confusion with <script> in templates
-  const jsonLdTag = `<${"script"} type="application/ld+json">${JSON.stringify(jsonLd, null, 2)}</${"script"}>`;
+  const jsonLdTag = $derived(
+    `<${"script"} type="application/ld+json">${JSON.stringify(jsonLd, null, 2)}</${"script"}>`
+  );
 </script>
 
 <svelte:head>
@@ -239,7 +247,7 @@
             <button
               type="button"
               class="w-full cursor-pointer p-3 font-bold text-skin-muted uppercase text-xs tracking-wider hover:text-skin-accent flex justify-between items-center select-none text-left"
-              on:click={() => toggleCategory(category)}
+              onclick={() => toggleCategory(category)}
             >
               {category}
               <span
@@ -292,7 +300,7 @@
       <div class="pt-4 space-y-3">
         {#if resume.experience.length > 3}
           <button
-            on:click={() => (showAllExperience = !showAllExperience)}
+            onclick={() => (showAllExperience = !showAllExperience)}
             class="text-sm text-skin-accent hover:underline font-mono"
           >
             {showAllExperience

--- a/site/src/lib/components/ResumeContent.svelte
+++ b/site/src/lib/components/ResumeContent.svelte
@@ -5,11 +5,15 @@
   import { addVariant } from "$lib/utils/variantLink";
   import "$lib/components/ui/glowing-green.css";
 
-  export let resume: Resume;
-  export let variant: string | null = null;
+  interface Props {
+    resume: Resume;
+    variant?: string | null;
+  }
 
-  $: formattedTitle = formatJobTitles(resume.jobTitles);
-  $: siteUrl = addVariant('/', variant);
+  let { resume, variant = null }: Props = $props();
+
+  const formattedTitle = $derived(formatJobTitles(resume.jobTitles));
+  const siteUrl = $derived(addVariant('/', variant));
 </script>
 
 <!-- Header -->

--- a/site/src/lib/components/ResumePage.svelte
+++ b/site/src/lib/components/ResumePage.svelte
@@ -3,11 +3,15 @@
     import SEO from "$lib/components/SEO.svelte";
     import type { Resume, SkillItem } from "$lib/types";
 
-    export let resume: Resume;
-    export let variant: string | null = null;
-    export let title: string;
-    export let description: string;
-    export let canonical: string;
+    interface Props {
+        resume: Resume;
+        variant?: string | null;
+        title: string;
+        description: string;
+        canonical: string;
+    }
+
+    let { resume, variant = null, title, description, canonical }: Props = $props();
 
     const formatSkillsAsDefinedTerms = (skills: Record<string, SkillItem[]>) => {
         const definedTerms: { "@type": string; name: string; url?: string; inDefinedTermSet: string }[] = [];
@@ -24,7 +28,7 @@
         return definedTerms;
     };
 
-    $: jsonLd = {
+    const jsonLd = $derived({
         "@context": "https://schema.org",
         "@type": "Person",
         name: resume.name,
@@ -66,10 +70,12 @@
             description: job.description,
         })),
         knowsAbout: formatSkillsAsDefinedTerms(resume.skills),
-    };
+    });
 
     // Build JSON-LD tag to avoid ESLint parser confusion with <script> in templates
-    $: jsonLdTag = `<${"script"} type="application/ld+json">${JSON.stringify(jsonLd, null, 2)}</${"script"}>`;
+    const jsonLdTag = $derived(
+        `<${"script"} type="application/ld+json">${JSON.stringify(jsonLd, null, 2)}</${"script"}>`
+    );
 </script>
 
 <SEO {title} {description} {canonical} />
@@ -82,7 +88,7 @@
     <div class="flex justify-end">
         <button
             class="px-4 py-2 bg-skin-accent text-skin-accent-contrast text-sm font-bold uppercase tracking-wider hover:opacity-90 transition-opacity rounded-md"
-            on:click={() => window.print()}
+            onclick={() => window.print()}
         >
             Print / Save as PDF
         </button>

--- a/site/src/lib/components/SEO.svelte
+++ b/site/src/lib/components/SEO.svelte
@@ -3,33 +3,46 @@
     import { page } from "$app/stores";
     // import { PUBLIC_ENV } from "$env/static/public";
 
-    export let title: string;
-    export let description: string;
-    export let type: string = "website";
-    export let image: string | undefined = undefined;
-    export let canonical: string | undefined = undefined;
-    export let keywords: string[] | undefined = undefined;
-    export let tags: string[] | undefined = undefined;
+    interface Props {
+        title: string;
+        description: string;
+        type?: string;
+        image?: string | undefined;
+        canonical?: string | undefined;
+        keywords?: string[] | undefined;
+        tags?: string[] | undefined;
+    }
 
-    // $: isDev = dev || PUBLIC_ENV === "dev";
-    $: finalTitle = dev ? `[dev] ${title}` : title;
+    let {
+        title,
+        description,
+        type = "website",
+        image = undefined,
+        canonical = undefined,
+        keywords = undefined,
+        tags = undefined
+    }: Props = $props();
+
+    const finalTitle = $derived(dev ? `[dev] ${title}` : title);
 
     // Default canonical to current URL if not provided, but remove query params for clean canonical
-    $: finalCanonical =
-        canonical ||
-        ($page.url ? `${$page.url.origin}${$page.url.pathname}` : undefined);
+    const finalCanonical = $derived(
+        canonical || ($page.url ? `${$page.url.origin}${$page.url.pathname}` : undefined)
+    );
 
     // Construct absolute image URL if provided; fall back to the default
     // social image (headshot) so every page emits og:image / twitter:image.
     const defaultImage = "/headshot.jpg";
-    $: finalImage = image
-        ? image.startsWith("http")
-            ? image
-            : `${$page.url.origin}${image}`
-        : `${$page.url.origin}${defaultImage}`;
+    const finalImage = $derived(
+        image
+            ? image.startsWith("http")
+                ? image
+                : `${$page.url.origin}${image}`
+            : `${$page.url.origin}${defaultImage}`
+    );
 
     // Combine tags and keywords for meta keywords
-    $: metaKeywords = [...(tags || []), ...(keywords || [])].join(", ");
+    const metaKeywords = $derived([...(tags || []), ...(keywords || [])].join(", "));
 </script>
 
 <svelte:head>

--- a/site/src/lib/components/VariantSwitcher.svelte
+++ b/site/src/lib/components/VariantSwitcher.svelte
@@ -1,23 +1,13 @@
 <script lang="ts">
   import { page } from '$app/stores';
-  import { onMount } from 'svelte';
+  import { browser } from '$app/environment';
   import { getCanonicalVariantPath, getVariant } from '$lib/utils/variantLink';
   import { variants } from '$lib/data/variants';
 
-  let currentVariant = 'default';
-  let currentPath = '/';
-
-  $: if (typeof window !== 'undefined' && $page) {
-    currentVariant = getVariant($page.url) || 'default';
-    currentPath = $page.url.pathname;
-  }
-
-  onMount(() => {
-    if ($page) {
-      currentVariant = getVariant($page.url) || 'default';
-      currentPath = $page.url.pathname;
-    }
-  });
+  // Resolve the active variant/path on the client (SSR keeps the neutral
+  // default, matching the prior onMount-driven behavior).
+  const currentVariant = $derived(browser ? getVariant($page.url) || 'default' : 'default');
+  const currentPath = $derived(browser ? $page.url.pathname : '/');
 </script>
 
 <div class="flex items-center gap-2 text-[10px] uppercase">

--- a/site/src/routes/+error.svelte
+++ b/site/src/routes/+error.svelte
@@ -5,9 +5,11 @@
   import { getCanonicalVariantPath } from "$lib/utils/variantLink";
   import SEO from "$lib/components/SEO.svelte";
 
-  $: rebootUrl = getCanonicalVariantPath(
-    "/",
-    browser ? $page.url.searchParams.get("v") : null,
+  const rebootUrl = $derived(
+    getCanonicalVariantPath(
+      "/",
+      browser ? $page.url.searchParams.get("v") : null,
+    ),
   );
 </script>
 

--- a/site/src/routes/+page.svelte
+++ b/site/src/routes/+page.svelte
@@ -5,16 +5,19 @@
   import { goto } from "$app/navigation";
   import { browser } from "$app/environment";
   import SEO from "$lib/components/SEO.svelte";
+  import type { PageData } from "./$types";
 
-  export let data;
+  let { data }: { data: PageData } = $props();
 
-  $: variant = browser ? $page.url.searchParams.get("v") : null;
-  $: if (browser && variant) {
-    const target = getRedirectTarget("/", variant);
-    if (target) {
-      goto(target, { replaceState: true });
+  const variant = $derived(browser ? $page.url.searchParams.get("v") : null);
+  $effect(() => {
+    if (browser && variant) {
+      const target = getRedirectTarget("/", variant);
+      if (target) {
+        goto(target, { replaceState: true });
+      }
     }
-  }
+  });
 </script>
 
 <SEO

--- a/site/src/routes/blog/+page.svelte
+++ b/site/src/routes/blog/+page.svelte
@@ -1,17 +1,14 @@
 <script lang="ts">
   import { page } from "$app/stores";
+  import { browser } from "$app/environment";
   import SEO from "$lib/components/SEO.svelte";
   import type { ContentItem } from "$lib/types";
   import { addVariant, getVariant, getCanonicalUrl } from "$lib/utils/variantLink";
-  import { onMount } from "svelte";
 
-  export let data: { posts: ContentItem[] };
-  $: posts = data.posts;
+  let { data }: { data: { posts: ContentItem[] } } = $props();
+  const posts = $derived(data.posts);
 
-  let variant: string | null = null;
-  onMount(() => {
-    variant = getVariant($page.url);
-  });
+  const variant = $derived(browser ? getVariant($page.url) : null);
 </script>
 
 <SEO

--- a/site/src/routes/builder/+page.svelte
+++ b/site/src/routes/builder/+page.svelte
@@ -2,8 +2,9 @@
   import { getCanonicalUrl } from "$lib/utils/variantLink";
   import Homepage from "$lib/components/Homepage.svelte";
   import SEO from "$lib/components/SEO.svelte";
+  import type { PageData } from "./$types";
 
-  export let data;
+  let { data }: { data: PageData } = $props();
 </script>
 
 <SEO

--- a/site/src/routes/builder/resume/+page.svelte
+++ b/site/src/routes/builder/resume/+page.svelte
@@ -3,11 +3,12 @@
   import ResumePage from "$lib/components/ResumePage.svelte";
   import { page } from "$app/stores";
   import { browser } from "$app/environment";
+  import type { PageData } from "./$types";
 
-  export let data;
-  const resume = data.resume;
+  let { data }: { data: PageData } = $props();
+  const resume = $derived(data.resume);
 
-  $: variant = browser ? $page.url.searchParams.get("v") : null;
+  const variant = $derived(browser ? $page.url.searchParams.get("v") : null);
 </script>
 
 <ResumePage

--- a/site/src/routes/ops/+page.svelte
+++ b/site/src/routes/ops/+page.svelte
@@ -2,8 +2,9 @@
   import { getCanonicalUrl } from "$lib/utils/variantLink";
   import Homepage from "$lib/components/Homepage.svelte";
   import SEO from "$lib/components/SEO.svelte";
+  import type { PageData } from "./$types";
 
-  export let data;
+  let { data }: { data: PageData } = $props();
 </script>
 
 <SEO

--- a/site/src/routes/ops/resume/+page.svelte
+++ b/site/src/routes/ops/resume/+page.svelte
@@ -3,11 +3,12 @@
   import ResumePage from "$lib/components/ResumePage.svelte";
   import { page } from "$app/stores";
   import { browser } from "$app/environment";
+  import type { PageData } from "./$types";
 
-  export let data;
-  const resume = data.resume;
+  let { data }: { data: PageData } = $props();
+  const resume = $derived(data.resume);
 
-  $: variant = browser ? $page.url.searchParams.get("v") : null;
+  const variant = $derived(browser ? $page.url.searchParams.get("v") : null);
 </script>
 
 <ResumePage

--- a/site/src/routes/projects/+page.svelte
+++ b/site/src/routes/projects/+page.svelte
@@ -8,8 +8,10 @@
     return browser ? url.searchParams.get("v") || null : null;
   }
 
-  export let data;
-  $: projects = data.projects;
+  import type { PageData } from "./$types";
+
+  let { data }: { data: PageData } = $props();
+  const projects = $derived(data.projects);
 </script>
 
 <SEO

--- a/site/src/routes/resume/+page.svelte
+++ b/site/src/routes/resume/+page.svelte
@@ -4,17 +4,20 @@
   import { page } from "$app/stores";
   import { goto } from "$app/navigation";
   import { browser } from "$app/environment";
+  import type { PageData } from "./$types";
 
-  export let data;
-  const resume = data.resume;
+  let { data }: { data: PageData } = $props();
+  const resume = $derived(data.resume);
 
-  $: variant = browser ? $page.url.searchParams.get("v") : null;
-  $: if (browser && variant) {
-    const target = getRedirectTarget("/resume", variant);
-    if (target) {
-      goto(target, { replaceState: true });
+  const variant = $derived(browser ? $page.url.searchParams.get("v") : null);
+  $effect(() => {
+    if (browser && variant) {
+      const target = getRedirectTarget("/resume", variant);
+      if (target) {
+        goto(target, { replaceState: true });
+      }
     }
-  }
+  });
 </script>
 
 <ResumePage


### PR DESCRIPTION
Architecture-showcase pass, **wave 4 of 4** (final). Converts the remaining Svelte 4 code to runes so the whole codebase is consistent and current.

## Changes (16 files)
- **Props** — every `export let` replaced with an `interface Props` + `$props()`: SEO, ResumeContent, ResumePage, ExperienceItem, Homepage, and all 8 route `+page.svelte` files. Route pages type `data` via `PageData` from `./$types`.
- **Reactivity** — every `$:` derivation becomes `$derived`; the reactive redirect side-effects in the home/resume pages become `$effect`.
- **State** — Homepage `openCategories`/`showAllExperience` become `$state`; prop-derived values (`jsonLd`, `currentJob`, `data.resume`) become `$derived` to avoid stale captures.
- **Events** — `on:click` -> `onclick`.
- **Cleanup** — VariantSwitcher and the blog page drop their `onMount`-then-assign pattern for `$derived`.

No behavior change; the app was already on Svelte 5, this makes the source uniformly idiomatic.

## Verification
`check` (0 errors) / `lint` / `test:unit` (27) / `build` all green. Verified in-browser (Playwright, desktop): home experience "show all" toggle (3->7 rows) and skill-category expand/collapse, the `/?v=ops` -> `/ops/` client redirect, footer active-variant highlight on `/ops/`, resume Print button, blog (4) and projects (9) lists, and the 404 error page all work.

Dev-only; production promotion remains a manual `workflow_dispatch`.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp