### PR TITLE
Fix modal header disappearing under the mobile keyboard

### DIFF
--- a/site/src/app.html
+++ b/site/src/app.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, interactive-widget=resizes-content"
+    />
     
     <!-- AI Content Signals / AI Preferences -->
     <meta name="ai-preferences" content="index, archive, summarize, train" />

--- a/site/src/lib/components/Modal.svelte
+++ b/site/src/lib/components/Modal.svelte
@@ -52,6 +52,45 @@
 
 	let panel = $state<HTMLElement | null>(null);
 
+	// Track the visual viewport so the mobile sheet hugs the space *above* the
+	// on-screen keyboard. 100dvh shrinks for browser chrome but not for the
+	// keyboard on iOS, so without this the header gets scrolled off the top when
+	// an input is focused. visualViewport.height/offsetTop follow the keyboard.
+	let isMobile = $state(false);
+	let vvHeight = $state(0);
+	let vvOffsetTop = $state(0);
+
+	$effect(() => {
+		if (!visible || !browser) return;
+
+		const mq = window.matchMedia('(max-width: 767px)');
+		const syncMobile = () => (isMobile = mq.matches);
+		syncMobile();
+		mq.addEventListener('change', syncMobile);
+
+		const vv = window.visualViewport;
+		const syncVv = () => {
+			if (!vv) return;
+			vvHeight = vv.height;
+			vvOffsetTop = vv.offsetTop;
+		};
+		syncVv();
+		vv?.addEventListener('resize', syncVv);
+		vv?.addEventListener('scroll', syncVv);
+
+		return () => {
+			mq.removeEventListener('change', syncMobile);
+			vv?.removeEventListener('resize', syncVv);
+			vv?.removeEventListener('scroll', syncVv);
+		};
+	});
+
+	// On mobile, pin the sheet to the visible viewport (falls back to the
+	// h-[100dvh] class when visualViewport is unavailable). Desktop uses classes.
+	const panelStyle = $derived(
+		isMobile && vvHeight ? `height:${vvHeight}px;transform:translateY(${vvOffsetTop}px);` : ''
+	);
+
 	function handleBackdropClick(e: MouseEvent) {
 		if (e.target === e.currentTarget) onClose();
 	}
@@ -141,6 +180,7 @@
 		<div
 			bind:this={panel}
 			tabindex="-1"
+			style={panelStyle}
 			class="bg-terminal-black border-terminal-green shadow-2xl w-full h-[100dvh] flex flex-col border-0 md:border-2 md:max-w-4xl focus:outline-none {fill
 				? 'md:h-[80vh]'
 				: 'md:h-auto md:max-h-[90vh]'}"


### PR DESCRIPTION
## Problem
`100dvh` shrinks for the browser's URL bar but **not** for the on-screen keyboard on iOS Safari. So focusing an input in a full-screen sheet made iOS scroll the focused field into view, pushing the modal header off the top of the screen. (The earlier "jumping" is gone; this was the residual.)

## Fix
- Size the mobile sheet to `window.visualViewport` (`height` + `offsetTop`), which **does** track the keyboard — the panel shrinks to the space above the keyboard and the `translateY(offsetTop)` keeps the header pinned to the visible top.
- Add `interactive-widget=resizes-content` to the viewport meta so Chrome/Android resizes the layout viewport (and `dvh`) when the keyboard opens.
- Desktop unaffected: inline sizing only applies under the `md` breakpoint, and it falls back to the existing `h-[100dvh]` class when `visualViewport` is unavailable.

## Verification
Playwright at 390x844: simulating a `visualViewport` resize to 500px shrank the panel to 500px with the header box pinned at `y:0`; desktop (1280x800) panel carried no inline sizing (normal centered card).

Dev-only; production promotion remains a manual `workflow_dispatch`.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp