### PR TITLE
Add starter prompts and AI-generated follow-up chips to the chat

### DIFF
--- a/site/functions/src/handlers.ts
+++ b/site/functions/src/handlers.ts
@@ -526,6 +526,47 @@ async function fetchContentIndexInner(): Promise<ContentIndex | null> {
 }
 
 /**
+ * Generate up to 3 short, contextual follow-up questions a visitor might ask
+ * next, based on the exchange that just happened. Best-effort: any failure
+ * (parse error, model error) resolves to an empty list so it never blocks or
+ * breaks the chat response.
+ */
+async function generateChatSuggestions(
+	ai: GoogleGenAI,
+	userMessage: string,
+	assistantResponse: string
+): Promise<string[]> {
+	try {
+		const result = await ai.models.generateContent({
+			model: 'gemini-2.5-flash',
+			config: {
+				maxOutputTokens: 200,
+				temperature: 0.4,
+				responseMimeType: 'application/json'
+			},
+			contents: `A visitor is chatting with an AI assistant about Brian Anderson, an engineering leader and hands-on builder, on his personal site.
+
+Their message: "${userMessage}"
+The assistant's answer: "${assistantResponse}"
+
+Suggest exactly 3 natural follow-up questions the visitor is likely to ask next to learn more about Brian. Each must be phrased in the visitor's own voice, under 8 words, and grounded in what was just discussed. Return ONLY a JSON array of 3 strings, e.g. ["...","...","..."].`
+		});
+
+		const parsed = JSON.parse(result.text || '[]');
+		if (!Array.isArray(parsed)) return [];
+		return parsed
+			.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
+			.map((s) => s.trim())
+			.slice(0, 3);
+	} catch (error) {
+		if (!IS_PRODUCTION) {
+			console.error('Chat suggestion generation failed:', error);
+		}
+		return [];
+	}
+}
+
+/**
  * Chat handler — can be called from Firebase Functions or Express/Cloud Run
  */
 export async function handleChat(req: Request, res: Response): Promise<void> {
@@ -677,9 +718,12 @@ export async function handleChat(req: Request, res: Response): Promise<void> {
 
 		const response = normalizeChatResponse(message, result.text || '', contentTools);
 
+		const suggestions = await generateChatSuggestions(ai, message, response);
+
 		res.set(corsHeadersFor(req));
 		res.status(200).json({
-			response
+			response,
+			suggestions
 		});
 
 	} catch (error) {

--- a/site/src/lib/components/ChatInput.svelte
+++ b/site/src/lib/components/ChatInput.svelte
@@ -63,9 +63,9 @@
 		oninput={handleInput}
 		placeholder="Ask about Brian's experience, skills, or paste a job description..."
 		class="flex-1 bg-transparent border border-terminal-green/30 rounded px-3 py-2 text-terminal-text font-mono text-sm resize-none focus:outline-none focus:border-terminal-green placeholder:text-terminal-text/50 disabled:opacity-50 disabled:cursor-not-allowed"
-		style="max-height: 200px; min-height: 40px;"
+		style="max-height: 200px; min-height: 56px;"
 		data-testid="chat-input"
-		rows="1"
+		rows="2"
 		{disabled}
 	></textarea>
 

--- a/site/src/lib/components/Chatbot.svelte
+++ b/site/src/lib/components/Chatbot.svelte
@@ -6,6 +6,7 @@
 	import ChatInput from './ChatInput.svelte';
 	import Modal from './Modal.svelte';
 	import { getApiBase } from '$lib/utils/apiBase';
+	import { fly } from 'svelte/transition';
 
 	const API_BASE = getApiBase();
 
@@ -20,6 +21,18 @@
 	let isLoading = $state(false);
 	let chatContainer = $state<HTMLDivElement | null>(null);
 	let focusTrigger = $state(0);
+	// Contextual follow-up chips returned by the API for the latest answer. Kept
+	// as structured data (never rendered into the message text), so they only ever
+	// appear as buttons, not as a flash of text in the reply.
+	let suggestions = $state<string[]>([]);
+
+	// Starter prompts shown when the chat is empty, to signal what visitors can ask.
+	const STARTER_QUESTIONS = [
+		"What's Brian's experience with AI?",
+		'Tell me about CampFit',
+		"What's his leadership background?",
+		"Is he a fit for a role I'm hiring for?"
+	];
 
 	// Load chat history from sessionStorage
 	onMount(() => {
@@ -76,6 +89,7 @@
 			timestamp: Date.now()
 		};
 		messages = [...messages, userMessage];
+		suggestions = [];
 
 		isLoading = true;
 
@@ -111,6 +125,7 @@
 				timestamp: Date.now()
 			};
 			messages = [...messages, assistantMessage];
+			suggestions = Array.isArray(data.suggestions) ? data.suggestions.slice(0, 3) : [];
 
 			// Trigger refocus after response
 			focusTrigger++;
@@ -133,6 +148,7 @@
 
 	function clearHistory() {
 		messages = [];
+		suggestions = [];
 		if (browser) {
 			sessionStorage.removeItem('chat_history');
 		}
@@ -164,6 +180,16 @@
 			<div class="text-center text-terminal-text/70 py-12">
 				<p class="text-lg mb-4">👋 Hi! I'm Brian's AI assistant.</p>
 				<p class="text-sm">Ask me about Brian's experience, skills, projects, or paste a job description for a fit analysis.</p>
+				<div class="mt-6 flex flex-wrap justify-center gap-2">
+					{#each STARTER_QUESTIONS as q (q)}
+						<button
+							onclick={() => handleSendMessage(q)}
+							class="text-xs text-terminal-green/90 border border-terminal-green/40 rounded-full px-3 py-1.5 hover:bg-terminal-green/10 active:bg-terminal-green/20 transition-colors"
+						>
+							{q}
+						</button>
+					{/each}
+				</div>
 			</div>
 		{/if}
 
@@ -180,6 +206,19 @@
 	</div>
 
 	<div class="border-t border-terminal-green/20 shrink-0">
+		{#if suggestions.length > 0 && !isLoading}
+			<div class="flex flex-wrap gap-2 px-4 pt-3">
+				{#each suggestions as q (q)}
+					<button
+						onclick={() => handleSendMessage(q)}
+						in:fly={{ y: 8, duration: 200 }}
+						class="text-xs text-left text-terminal-green/90 border border-terminal-green/40 rounded-full px-3 py-1.5 hover:bg-terminal-green/10 active:bg-terminal-green/20 transition-colors"
+					>
+						{q}
+					</button>
+				{/each}
+			</div>
+		{/if}
 		<ChatInput onSend={handleSendMessage} disabled={isLoading} autoFocus={visible} focusTrigger={focusTrigger} />
 	</div>
 </Modal>


### PR DESCRIPTION
Two chat UX upgrades: discoverability (what can I ask?) and contextual follow-ups.

## What
- **AI follow-up chips** — `handleChat` generates up to 3 contextual follow-up questions from the exchange (a small, isolated `gemini-2.5-flash` JSON call) and returns them as a separate `suggestions` array. They render **only as tappable chip buttons** above the input (subtle fly-in), never as text in the reply — so nothing flashes into the streamed message. Chips clear on send and repopulate from the next answer.
- **Starter chips** — the empty state shows four starter questions so visitors see what they can ask.
- **2-row input** — the chat textarea now defaults to 2 rows so the full placeholder is visible.

## Safety / rollout
- Best-effort: any failure in suggestion generation resolves to `[]` and never blocks or breaks the reply.
- **Graceful degradation**: if the deployed API omits `suggestions`, no chips render (`data.suggestions` undefined → `[]`), so the frontend and the Cloud Run backend can deploy independently in any order.
- Existing chat AI evals read only `.response`, which is unchanged.

## Verification
`functions` tsc + site `check` / `lint` / `test:unit` (27) / `build` all green. Playwright (mocked `/chat`): 4 starter chips; 2-row input (58px, full placeholder shown); starter-click sends; the 3 follow-ups appear as **buttons** and **none of their text leaks into the assistant message bubble**; clicking a chip sends it, clears chips during "Thinking…", and repopulates.

Dev-only; production promotion (which is what actually enables the backend suggestion generation) remains a manual `workflow_dispatch`.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp