### PR TITLE
Fix empty chat suggestions; Fit Finder fills sheet; trim hero

### DIFF
--- a/site/functions/src/handlers.ts
+++ b/site/functions/src/handlers.ts
@@ -2,7 +2,7 @@
  * Extracted handler logic for chat and fit-finder functions.
  * Shared between Firebase Functions (local dev) and Cloud Run (production).
  */
-import { GoogleGenAI } from '@google/genai';
+import { GoogleGenAI, Type } from '@google/genai';
 import { getSystemPrompt } from './systemPrompt.js';
 import { checkGuardrails, getRefusalMessage } from './guardrails.js';
 import {
@@ -536,25 +536,40 @@ async function generateChatSuggestions(
 	userMessage: string,
 	assistantResponse: string
 ): Promise<string[]> {
-	try {
-		const result = await ai.models.generateContent({
-			model: 'gemini-2.5-flash',
-			config: {
-				maxOutputTokens: 200,
-				temperature: 0.4,
-				responseMimeType: 'application/json'
-			},
-			contents: `A visitor is chatting with an AI assistant about Brian Anderson, an engineering leader and hands-on builder, on his personal site.
+	const prompt = `A visitor is chatting with an AI assistant about Brian Anderson, an engineering leader and hands-on builder, on his personal site.
 
 Their message: "${userMessage}"
 The assistant's answer: "${assistantResponse}"
 
-Suggest exactly 3 natural follow-up questions the visitor is likely to ask next to learn more about Brian. Each must be phrased in the visitor's own voice, under 8 words, and grounded in what was just discussed. Return ONLY a JSON array of 3 strings, e.g. ["...","...","..."].`
+Suggest exactly 3 natural follow-up questions the visitor is likely to ask next to learn more about Brian. Each must be phrased in the visitor's own voice, under 8 words, and grounded in what was just discussed. Return a JSON array of 3 strings.`;
+
+	try {
+		const result = await ai.models.generateContent({
+			model: 'gemini-2.5-flash',
+			config: {
+				maxOutputTokens: 300,
+				temperature: 0.4,
+				responseMimeType: 'application/json',
+				// Force a bare array of strings; without a schema the model often
+				// wraps the list in an object (e.g. { questions: [...] }).
+				responseSchema: {
+					type: Type.ARRAY,
+					items: { type: Type.STRING }
+				}
+			},
+			contents: [{ role: 'user', parts: [{ text: prompt }] }]
 		});
 
-		const parsed = JSON.parse(result.text || '[]');
-		if (!Array.isArray(parsed)) return [];
-		return parsed
+		const raw = (result.text || '').trim();
+		if (!raw) return [];
+		const parsed: unknown = JSON.parse(raw);
+		// Accept a bare array, or the first array value of an object wrapper.
+		const arr: unknown[] = Array.isArray(parsed)
+			? parsed
+			: parsed && typeof parsed === 'object'
+				? (Object.values(parsed).find(Array.isArray) as unknown[] | undefined) ?? []
+				: [];
+		return arr
 			.filter((s): s is string => typeof s === 'string' && s.trim().length > 0)
 			.map((s) => s.trim())
 			.slice(0, 3);

--- a/site/src/lib/components/FitFinder.svelte
+++ b/site/src/lib/components/FitFinder.svelte
@@ -144,6 +144,7 @@
 	labelledby="fit-finder-title"
 	closeLabel="Close fit finder"
 	testid="fit-finder"
+	fill
 >
 	{#snippet actions()}
 		{#if analysis}
@@ -157,49 +158,45 @@
 		{/if}
 	{/snippet}
 
-	<div class="flex-1 min-h-0 overflow-y-auto p-6 space-y-6">
-				{#if !analysis}
-					<!-- Input Section -->
-					<div class="space-y-4">
-						<div>
-							<label for="job-description" class="block text-terminal-green text-sm font-mono mb-2">
-								📄 Paste Job Description or Project Requirements
-							</label>
-							<textarea
-								id="job-description"
-								bind:value={jobDescription}
-								placeholder="Paste the full job description here..."
-								class="w-full bg-terminal-dark border border-terminal-green/30 rounded px-3 py-2 text-terminal-text font-mono text-sm resize-none focus:outline-none focus:border-terminal-green placeholder:text-terminal-text/50"
-								rows="12"
-								data-testid="jd-input"
-							></textarea>
-							<div class="text-xs text-terminal-text/50 mt-1">
-								{jobDescription.length} characters
-							</div>
-						</div>
+	{#if !analysis}
+		<!-- Input: the textarea fills the sheet, Analyze stays pinned at the bottom -->
+		<div class="flex-1 min-h-0 flex flex-col gap-4 p-6">
+			<label for="job-description" class="shrink-0 block text-terminal-green text-sm font-mono">
+				📄 Paste Job Description or Project Requirements
+			</label>
+			<textarea
+				id="job-description"
+				bind:value={jobDescription}
+				placeholder="Paste the full job description here..."
+				class="flex-1 min-h-0 w-full bg-terminal-dark border border-terminal-green/30 rounded px-3 py-2 text-terminal-text font-mono text-sm resize-none focus:outline-none focus:border-terminal-green placeholder:text-terminal-text/50"
+				data-testid="jd-input"
+			></textarea>
+			<div class="shrink-0 text-xs text-terminal-text/50">
+				{jobDescription.length} characters
+			</div>
 
-						{#if error}
-							<div class="p-3 bg-red-500/10 border border-red-500/30 rounded text-red-500 text-sm">
-								❌ {error}
-							</div>
-						{/if}
+			{#if error}
+				<div class="shrink-0 p-3 bg-red-500/10 border border-red-500/30 rounded text-red-500 text-sm">
+					❌ {error}
+				</div>
+			{/if}
 
-						<button
-							onclick={handleAnalyze}
-							disabled={isAnalyzing || !jobDescription.trim()}
-							class="w-full bg-terminal-green/10 border-2 border-terminal-green rounded px-6 py-3 text-terminal-green font-mono font-semibold hover:bg-terminal-green/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-							data-testid="analyze-button"
-						>
-							{#if isAnalyzing}
-								<span class="animate-pulse">Analyzing...</span>
-							{:else}
-								Analyze Fit
-							{/if}
-						</button>
-					</div>
+			<button
+				onclick={handleAnalyze}
+				disabled={isAnalyzing || !jobDescription.trim()}
+				class="shrink-0 w-full bg-terminal-green/10 border-2 border-terminal-green rounded px-6 py-3 text-terminal-green font-mono font-semibold hover:bg-terminal-green/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+				data-testid="analyze-button"
+			>
+				{#if isAnalyzing}
+					<span class="animate-pulse">Analyzing...</span>
 				{:else}
-					<!-- Results Section -->
-					<div class="space-y-6">
+					Analyze Fit
+				{/if}
+			</button>
+		</div>
+	{:else}
+		<!-- Results: scrollable -->
+		<div class="flex-1 min-h-0 overflow-y-auto space-y-6 p-6">
 						<!-- Fit Level & Score -->
 						<div class="p-4 bg-terminal-dark border border-terminal-green/20 rounded">
 							<div class="flex items-center justify-between mb-4">
@@ -364,5 +361,4 @@
 						{/if}
 					</div>
 				{/if}
-			</div>
 </Modal>

--- a/site/src/lib/components/Homepage.svelte
+++ b/site/src/lib/components/Homepage.svelte
@@ -54,14 +54,6 @@
     blog: addVariant('/blog/', variant)
   });
 
-  const recruiterSummary = $derived(
-    variant === "ops"
-      ? "I build reliable delivery platforms and observability systems for high-stakes production environments, and I apply that same discipline to AI workloads."
-      : variant === "builder"
-        ? "I ship production software across the stack and now build agent-driven products with tracing, tool orchestration, and evaluation in mind."
-        : "I help enterprises modernize delivery systems at scale and now bring that same rigor to AI platforms, agent workflows, and developer productivity."
-  );
-
   const proofPoints = $derived(
     variant === "ops"
       ? [
@@ -138,10 +130,6 @@
           </h1>
             <p class="mb-6 opacity-80">
               {resume.tagline}
-            </p>
-
-            <p class="mb-6 text-terminal-text/90">
-              {recruiterSummary}
             </p>
 
             <div class="mb-4 text-terminal-green">$ cat mission.txt</div>


### PR DESCRIPTION
Three fixes from live feedback on dev.

## 1. Chat follow-up chips were never appearing
The dev API returned `suggestions: []` every time. **Root cause:** with `responseMimeType: application/json` but no schema, Gemini wraps the list in an object (`{ questions: [...] }`), so `Array.isArray()` failed and it fell back to `[]`. **Fix:** force a bare string array via `responseSchema` (`Type.ARRAY`/`Type.STRING`), pass structured `contents`, and parse defensively (also accept an object-wrapped array). Still best-effort → `[]` on any error.

## 2. Fit Finder fills the sheet
The job-description textarea now flexes to fill the available height and the **Analyze button is pinned at the bottom** (Modal uses `fill`, so desktop is a fixed-height panel too). Previously a fixed 12-row box with dead space below on mobile.

## 3. Homepage hero trim
Dropped the recruiter-summary paragraph, which duplicated the tagline above it and the mission below it. Tagline + mission + proof stats remain.

## Verification
`functions` tsc + site `check` / `lint` / `test:unit` (27) / `build` green. Playwright (390x844 + 1280x800): Fit Finder textarea fills (~578px on mobile) with Analyze pinned at the bottom on both viewports. **The suggestions fix will be verified against live dev after this deploys** (it needs the Cloud Run function).

Dev-only; production promotion remains a manual `workflow_dispatch`.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp