### PR TITLE
Fix empty chat suggestions: disable thinking on the suggestion call

### DIFF
--- a/site/functions/src/handlers.ts
+++ b/site/functions/src/handlers.ts
@@ -547,8 +547,13 @@ Suggest exactly 3 natural follow-up questions the visitor is likely to ask next 
 		const result = await ai.models.generateContent({
 			model: 'gemini-2.5-flash',
 			config: {
-				maxOutputTokens: 300,
+				maxOutputTokens: 512,
 				temperature: 0.4,
+				// Gemini 2.5 Flash enables "thinking" by default, which spends the
+				// output-token budget before any text is produced; on a small budget
+				// that leaves an empty response. This is a trivial structured task, so
+				// disable thinking for a fast, reliable JSON answer.
+				thinkingConfig: { thinkingBudget: 0 },
 				responseMimeType: 'application/json',
 				// Force a bare array of strings; without a schema the model often
 				// wraps the list in an object (e.g. { questions: [...] }).
@@ -561,7 +566,10 @@ Suggest exactly 3 natural follow-up questions the visitor is likely to ask next 
 		});
 
 		const raw = (result.text || '').trim();
-		if (!raw) return [];
+		if (!raw) {
+			console.warn('Chat suggestions: empty model response');
+			return [];
+		}
 		const parsed: unknown = JSON.parse(raw);
 		// Accept a bare array, or the first array value of an object wrapper.
 		const arr: unknown[] = Array.isArray(parsed)
@@ -574,9 +582,7 @@ Suggest exactly 3 natural follow-up questions the visitor is likely to ask next 
 			.map((s) => s.trim())
 			.slice(0, 3);
 	} catch (error) {
-		if (!IS_PRODUCTION) {
-			console.error('Chat suggestion generation failed:', error);
-		}
+		console.error('Chat suggestion generation failed:', error);
 		return [];
 	}
 }


### PR DESCRIPTION
Follow-up to #75 — the chat follow-up chips were still coming back empty on dev. Now root-caused and fixed with a **local reproduction against the live Gemini API**.

## Root cause (confirmed, not guessed)
`gemini-2.5-flash` enables "thinking" by default, which spends the output-token budget before producing any text. With `maxOutputTokens: 300`, the call finished with `finishReason: MAX_TOKENS` and a truncated non-JSON preamble (`"Here is the JSON requested: \`\`\`json"`), so `JSON.parse` threw and the handler fell back to `[]`.

Local repro:
- old config → `finishReason: MAX_TOKENS`, garbage text → `[]`
- new config → `finishReason: STOP`, `["What is Brian's role?","How does CampFit work?","What technologies were used?"]`

## Fix
- `thinkingConfig: { thinkingBudget: 0 }` — disable thinking for this trivial structured task (also faster/cheaper).
- `maxOutputTokens: 512`.
- Log suggestion failures unconditionally so any future regression shows up in Cloud Run logs.

## Verification
`functions` tsc green; the config was proven end-to-end against the real API locally. Will confirm on live dev after deploy.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp