### PR TITLE
Link proof stats to case studies + add reveal-on-scroll animations

### DIFF
--- a/site/src/lib/actions/reveal.ts
+++ b/site/src/lib/actions/reveal.ts
@@ -1,0 +1,45 @@
+interface RevealOptions {
+	/** Delay in ms before the element animates in (used to stagger groups). */
+	delay?: number;
+	/** Vertical offset in px the element rises from. */
+	y?: number;
+}
+
+/**
+ * Reveal-on-scroll: fades and rises an element into view the first time it
+ * enters the viewport, then stops observing. Honors prefers-reduced-motion
+ * (no-op) and is SSR-safe (only runs client-side as a Svelte action).
+ *
+ * Usage: `use:reveal` or `use:reveal={{ delay: 80, y: 16 }}`.
+ */
+export function reveal(node: HTMLElement, options: RevealOptions = {}) {
+	const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+	if (reduceMotion) return;
+
+	const { delay = 0, y = 12 } = options;
+
+	node.style.opacity = '0';
+	node.style.transform = `translateY(${y}px)`;
+	node.style.transition = `opacity 500ms ease-out ${delay}ms, transform 500ms ease-out ${delay}ms`;
+	node.style.willChange = 'opacity, transform';
+
+	const io = new IntersectionObserver(
+		(entries) => {
+			for (const entry of entries) {
+				if (!entry.isIntersecting) continue;
+				node.style.opacity = '1';
+				node.style.transform = 'none';
+				io.unobserve(node);
+			}
+		},
+		{ threshold: 0.1, rootMargin: '0px 0px -40px 0px' }
+	);
+
+	io.observe(node);
+
+	return {
+		destroy() {
+			io.disconnect();
+		}
+	};
+}

--- a/site/src/lib/components/Homepage.svelte
+++ b/site/src/lib/components/Homepage.svelte
@@ -5,6 +5,7 @@
   import ExperienceItem from "$lib/components/ExperienceItem.svelte";
   import { formatJobTitles } from "$lib/utils/formatters";
   import { addVariant } from "$lib/utils/variantLink";
+  import { reveal } from "$lib/actions/reveal";
 
   interface Props {
     resume: Resume;
@@ -54,26 +55,27 @@
     blog: addVariant('/blog/', variant)
   });
 
+  // Each proof point links to the case study that substantiates it.
   const proofPoints = $derived(
     variant === "ops"
       ? [
-          "14 mission-critical apps migrated with zero downtime",
-          "90% deployment lead-time reduction",
-          "8-9 production deployments per day",
-          "Agent runs traced end-to-end: OTel + Grafana"
+          { text: "14 mission-critical apps migrated with zero downtime", href: "/projects/discover-trident/" },
+          { text: "90% deployment lead-time reduction", href: "/projects/gfs-cloud-enablement/" },
+          { text: "8-9 production deployments per day", href: "/projects/gfs-ordering-platform/" },
+          { text: "Agent runs traced end-to-end: OTel + Grafana", href: "/projects/stallion-agent-platform/" }
         ]
       : variant === "builder"
         ? [
-            "Top 0.03% of 280k+ Amazon Kiro CLI users",
-            "Reusable Kiro agent workflows, gated by promptfoo evals",
-            "Agent platform: MCP orchestration + prompt evals + OTel tracing",
-            "16+ years shipping mobile, web, and cloud apps"
+            { text: "Top 0.03% of 280k+ Amazon Kiro CLI users", href: "/projects/kiro-agent-workflows/" },
+            { text: "Reusable Kiro agent workflows, gated by promptfoo evals", href: "/projects/kiro-agent-workflows/" },
+            { text: "Agent platform: MCP orchestration + prompt evals + OTel tracing", href: "/projects/stallion-agent-platform/" },
+            { text: "16+ years shipping mobile, web, and cloud apps", href: "/resume/" }
           ]
         : [
-            "CI/CD standardization across 5,000+ enterprise apps",
-            "New features and responses to customer feedback shipped in 8-9 production deployments per day",
-            "90% deployment lead-time reduction & $30M estimated savings",
-            "Top 0.03% of 280k+ Amazon Kiro CLI users"
+            { text: "CI/CD standardization across 5,000+ enterprise apps", href: "/projects/gfs-cloud-enablement/" },
+            { text: "New features and responses to customer feedback shipped in 8-9 production deployments per day", href: "/projects/gfs-ordering-platform/" },
+            { text: "90% deployment lead-time reduction & $30M estimated savings", href: "/projects/gfs-cloud-enablement/" },
+            { text: "Top 0.03% of 280k+ Amazon Kiro CLI users", href: "/projects/kiro-agent-workflows/" }
           ]
   );
 
@@ -203,9 +205,18 @@
           <div class="mt-8">
             <div class="mb-4 text-terminal-green">$ cat selected-proof.log</div>
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-2 text-sm">
-              {#each proofPoints as proofPoint}
-                <div class="border border-terminal-border px-3 py-2 text-terminal-text/90">
-                  {proofPoint}
+              {#each proofPoints as proofPoint, i (proofPoint.text)}
+                <div use:reveal={{ delay: i * 80 }} class="h-full">
+                  <a
+                    href={addVariant(proofPoint.href, variant)}
+                    class="group h-full flex items-start justify-between gap-2 border border-terminal-border px-3 py-2 text-terminal-text/90 rounded hover:border-terminal-green hover:bg-terminal-green/5 hover:text-terminal-text hover:shadow-[0_0_12px_rgba(var(--color-terminal-accent),0.15)] transition-colors duration-200"
+                  >
+                    <span>{proofPoint.text}</span>
+                    <span
+                      class="shrink-0 text-terminal-green opacity-0 -translate-x-1 group-hover:opacity-100 group-hover:translate-x-0 transition-all duration-200"
+                      aria-hidden="true">↗</span
+                    >
+                  </a>
                 </div>
               {/each}
             </div>
@@ -220,7 +231,7 @@
 <section id="skills" class="py-12 border-t border-dashed border-skin-border">
   <div class="max-w-4xl mx-auto px-4">
     <article>
-      <div class="flex items-center gap-2 mb-6 text-skin-accent font-mono">
+      <div use:reveal class="flex items-center gap-2 mb-6 text-skin-accent font-mono">
         <span>></span>
         <h2 class="text-xl font-bold">SYSTEM_MODULES_LOADED</h2>
       </div>
@@ -228,8 +239,9 @@
       <div
         class="grid grid-cols-1 md:grid-cols-2 gap-4 items-start font-mono text-sm"
       >
-        {#each Object.entries(resume.skills) as [category, items]}
+        {#each Object.entries(resume.skills) as [category, items], i (category)}
           <div
+            use:reveal={{ delay: i * 60 }}
             class="group bg-skin-page border border-skin-border rounded shadow-sm overflow-hidden"
           >
             <button
@@ -274,12 +286,13 @@
   class="py-12 border-t border-dashed border-skin-border"
 >
   <div class="max-w-4xl mx-auto px-4">
-    <div class="flex items-center gap-2 mb-6 text-skin-accent font-mono">
+    <div use:reveal class="flex items-center gap-2 mb-6 text-skin-accent font-mono">
       <span>></span>
       <h2 class="text-xl font-bold">WORK_HISTORY_LOG</h2>
     </div>
 
     <div
+      use:reveal
       class="space-y-6 font-mono border-l-2 border-skin-border ml-2 pl-6 relative hover:z-10"
     >
       {#each showAllExperience ? resume.experience : resume.experience.slice(0, 3) as job}
@@ -309,7 +322,7 @@
 <!-- Contact/Footer Section -->
 <section id="contact" class="py-12 border-t border-dashed border-skin-border">
   <div class="max-w-4xl mx-auto px-4">
-    <div class="flex items-center gap-2 mb-6 text-skin-accent font-mono">
+    <div use:reveal class="flex items-center gap-2 mb-6 text-skin-accent font-mono">
       <span>></span>
       <h2 class="text-xl font-bold">INITIATE_CONTACT</h2>
     </div>


### PR DESCRIPTION
## What

The homepage's four **selected-proof** stats now *do something*: each links out to the relevant case-study project page, so the numbers are a jumping-off point rather than static text. Also adds page-wide reveal-on-scroll motion.

### Proof stats → case studies
- CI/CD across 5,000+ apps → `/projects/gfs-cloud-enablement/`
- 8-9 deploys/day → `/projects/gfs-ordering-platform/`
- 90% lead-time reduction / \$30M savings → `/projects/gfs-cloud-enablement/`
- Top 0.03% of 280k+ Kiro users → `/projects/kiro-agent-workflows/`
- Hover affordance: green border + subtle tint and a fading `↗` arrow.
- Destinations are variant-aware (`addVariant`) and swap per audience variant (default / ops / builder).

### Reveal-on-scroll animation
- New `site/src/lib/actions/reveal.ts` Svelte action: fades + rises an element into view the first time it enters the viewport (IntersectionObserver), then stops observing.
- Applied with a stagger to section headers, skill cards, proof cards, and the experience timeline.
- Honors `prefers-reduced-motion` (no-op) and is SSR-safe.

## Verification (Playwright, localhost preview)
| Check | Result |
|---|---|
| Proof cards are `<a>` links | PASS |
| All links resolve 200 to real project pages | PASS |
| Hover arrow + border/bg change | PASS |
| Nothing stuck at opacity 0 after normal scroll | PASS |
| Reduced motion: content visible without scroll | PASS |

`svelte-check`, lint, and build all pass (2 pre-existing Lightbox a11y warnings unrelated to this change).

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp