### PR TITLE
Shorten dev HTML cache to 60s for faster iteration

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -365,7 +365,7 @@ jobs:
           fi
 
           # Upload everything else (standard cache)
-          gcloud storage rsync site/build/ gs://dev.briananderson.xyz/ --recursive --delete-unmatched-destination-objects --cache-control="public, max-age=3600, must-revalidate"
+          gcloud storage rsync site/build/ gs://dev.briananderson.xyz/ --recursive --delete-unmatched-destination-objects --cache-control="public, max-age=60, must-revalidate"
       - name: Warm up dev API services
         run: |
           echo "Warming up dev Cloud Run services..."
@@ -439,7 +439,7 @@ jobs:
             gcloud storage cp site/build/content-index.json gs://dev.briananderson.xyz/ --cache-control="public, max-age=300, must-revalidate"
           fi
 
-          gcloud storage rsync site/build/ gs://dev.briananderson.xyz/ --recursive --delete-unmatched-destination-objects --cache-control="public, max-age=3600, must-revalidate"
+          gcloud storage rsync site/build/ gs://dev.briananderson.xyz/ --recursive --delete-unmatched-destination-objects --cache-control="public, max-age=60, must-revalidate"
           echo "Rollback complete."
           exit 1
       - name: Fail if smoke tests failed


### PR DESCRIPTION
## Why
Dev page HTML was served with `max-age=3600, must-revalidate`, so newly deployed page changes could take up to an hour to appear (or require a hard refresh) — annoying while iterating, and it's what made the proof-links/animations change look "not deployed" on mobile even though it was live.

## Change
- Dev general `rsync site/build/` cache-control: `max-age=3600` → `max-age=60, must-revalidate` (2 occurrences: main deploy + redeploy path).
- **Production untouched** — all three prod/`$BUCKET` rsync lines stay at `max-age=3600`.
- Content-hashed `_app/immutable` assets keep their `max-age=31536000, immutable` cache (safe — filenames change on every build).

Dev-only, low-traffic bucket, so the extra revalidation cost is negligible.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp