### PR TITLE
Cross-page view transitions + reveal-on-scroll on projects & blog

### DIFF
--- a/site/src/lib/styles/app.css
+++ b/site/src/lib/styles/app.css
@@ -102,3 +102,29 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .prose pre { overflow: auto; border: 1px solid rgb(var(--color-border)); }
+
+/* ---- Cross-page view transitions ----------------------------------------
+   Wired up in +layout.svelte via onNavigate + document.startViewTransition.
+   The outgoing page fades and lifts up slightly while the incoming page fades
+   and rises into place, giving navigation a gentle continuity. Browsers
+   without the View Transitions API ignore these rules and navigate instantly. */
+@keyframes vt-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+}
+@keyframes vt-fade-out {
+  to { opacity: 0; transform: translateY(-8px); }
+}
+::view-transition-old(root) {
+  animation: vt-fade-out 200ms cubic-bezier(0.4, 0, 1, 1) both;
+}
+::view-transition-new(root) {
+  animation: vt-fade-in 260ms cubic-bezier(0, 0, 0.2, 1) both;
+}
+
+/* Respect reduced-motion everywhere: no reveal, no view-transition movement. */
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation: none;
+  }
+}

--- a/site/src/routes/+layout.svelte
+++ b/site/src/routes/+layout.svelte
@@ -13,7 +13,7 @@
   import { trackEvent } from "$lib/utils/analytics";
   import { initWebVitals } from "$lib/utils/web-vitals";
   import { browser } from "$app/environment";
-  import { beforeNavigate, afterNavigate } from "$app/navigation";
+  import { beforeNavigate, afterNavigate, onNavigate } from "$app/navigation";
   import posthog from "posthog-js";
   import { PUBLIC_POSTHOG_KEY, PUBLIC_POSTHOG_HOST } from "$env/static/public";
   import ExternalLinkModal from "$lib/components/ExternalLinkModal.svelte";
@@ -199,6 +199,21 @@
         return; // Handled by onMount
       }
       posthog.capture("$pageview");
+    });
+
+    // Cross-page transitions via the native View Transitions API. Progressive
+    // enhancement: browsers without startViewTransition just navigate instantly,
+    // and we opt out entirely under prefers-reduced-motion. The actual fade/rise
+    // animation lives in app.css (::view-transition-old/new(root)).
+    onNavigate((navigation) => {
+      if (!document.startViewTransition) return;
+      if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+      return new Promise((resolve) => {
+        document.startViewTransition(async () => {
+          resolve();
+          await navigation.complete;
+        });
+      });
     });
   }
 </script>

--- a/site/src/routes/blog/+page.svelte
+++ b/site/src/routes/blog/+page.svelte
@@ -4,6 +4,7 @@
   import SEO from "$lib/components/SEO.svelte";
   import type { ContentItem } from "$lib/types";
   import { addVariant, getVariant, getCanonicalUrl } from "$lib/utils/variantLink";
+  import { reveal } from "$lib/actions/reveal";
 
   let { data }: { data: { posts: ContentItem[] } } = $props();
   const posts = $derived(data.posts);
@@ -34,7 +35,8 @@
       <div class="col-span-9 md:col-span-10">Title / Description</div>
     </div>
 
-    {#each posts as post}
+    {#each posts as post, i}
+      <div use:reveal={{ delay: i * 50 }}>
       <a
         href={addVariant(post.route, variant)}
         class="group grid grid-cols-12 gap-4 items-start p-4 hover:bg-skin-base/5 border-l-2 border-transparent hover:border-skin-accent transition-all rounded-r-lg"
@@ -64,6 +66,7 @@
           {/if}
         </div>
       </a>
+      </div>
     {/each}
   </div>
 </section>

--- a/site/src/routes/projects/+page.svelte
+++ b/site/src/routes/projects/+page.svelte
@@ -3,6 +3,7 @@
   import { browser } from "$app/environment";
   import { addVariant, getCanonicalUrl } from "$lib/utils/variantLink";
   import SEO from "$lib/components/SEO.svelte";
+  import { reveal } from "$lib/actions/reveal";
 
   function getVariant(url: URL): string | null {
     return browser ? url.searchParams.get("v") || null : null;
@@ -30,7 +31,8 @@
   </p>
 
   <div class="grid md:grid-cols-2 gap-6">
-    {#each projects as p}
+    {#each projects as p, i}
+      <div use:reveal={{ delay: i * 60 }}>
       <a
         href={addVariant(p.route, getVariant($page.url))}
         class="group block border border-skin-border bg-skin-base/5 hover:border-skin-accent hover:shadow-[0_0_10px_rgba(var(--color-accent),0.1)] transition-all duration-300 rounded-lg overflow-hidden"
@@ -78,6 +80,7 @@
           {/if}
         </div>
       </a>
+      </div>
     {/each}
   </div>
 </section>


### PR DESCRIPTION
## What
Extends the homepage's motion to the whole site.

### 1. Cross-page transitions (all pages)
- Native **View Transitions API** wired through SvelteKit's `onNavigate` in the root layout.
- Outgoing page fades + lifts, incoming page fades + rises (`::view-transition-old/new(root)` in `app.css`).
- Progressive enhancement — browsers without `document.startViewTransition` just navigate instantly.
- Fully disabled under `prefers-reduced-motion`.

### 2. Reveal-on-scroll on list pages
- The existing `reveal` action (was homepage-only) now decorates `/projects` cards and `/blog` rows, each wrapped in a `use:reveal` div with a stagger.
- Wrapper-div pattern (not on the `<a>` itself) so each card keeps its own hover transition.

## Verification (Playwright, preview build)
| Check | Result |
|---|---|
| `document.startViewTransition` present + `vt-fade-in`/`::view-transition-new(root)` rules in stylesheet | PASS |
| Home→Projects→Blog→Home navigations complete (36-61ms, no hangs) | PASS |
| Projects cards settle at opacity 1 after scroll (0.44 → 1 mid-animation observed) | PASS |
| Blog rows settle at opacity 1 | PASS |
| Reduced motion: cards visible with no scroll; navigation still works | PASS |
| No console errors referencing view-transition / onNavigate / reveal | PASS |

`svelte-check` (0 errors), lint, and build all pass. Only console noise is a pre-existing PostHog placeholder 404 in local preview, unrelated to this change.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp