### PR TITLE
Shared-element title morph + detail-page headers & resume reveals

### DIFF
--- a/site/src/lib/actions/reveal.ts
+++ b/site/src/lib/actions/reveal.ts
@@ -22,6 +22,10 @@ export function reveal(node: HTMLElement, options: RevealOptions = {}) {
 	node.style.transform = `translateY(${y}px)`;
 	node.style.transition = `opacity 500ms ease-out ${delay}ms, transform 500ms ease-out ${delay}ms`;
 	node.style.willChange = 'opacity, transform';
+	// Marker for the print override in app.css: a section that hasn't scrolled
+	// into view yet would otherwise print at opacity 0 (blank), which matters
+	// for the printable resume. The @media print rule forces these visible.
+	node.classList.add('reveal-init');
 
 	const io = new IntersectionObserver(
 		(entries) => {

--- a/site/src/lib/components/ResumeContent.svelte
+++ b/site/src/lib/components/ResumeContent.svelte
@@ -3,6 +3,7 @@
   import { getDuration } from "$lib/utils/date";
   import { formatJobTitles } from "$lib/utils/formatters";
   import { addVariant } from "$lib/utils/variantLink";
+  import { reveal } from "$lib/actions/reveal";
   import "$lib/components/ui/glowing-green.css";
 
   interface Props {
@@ -70,7 +71,7 @@
 </header>
 
 <!-- Summary -->
-<section class="mb-10 print:mb-4">
+<section use:reveal class="mb-10 print:mb-4">
   <div
     class="flex items-center gap-2 mb-3 text-skin-accent text-sm uppercase tracking-wider print:text-black print:font-bold print:mb-1 print:text-xs"
   >
@@ -86,7 +87,7 @@
 
 <!-- Skills -->
 {#if resume.skills}
-  <section class="mb-10 print:mb-2 print:mt-2 break-inside-avoid">
+  <section use:reveal class="mb-10 print:mb-2 print:mt-2 break-inside-avoid">
     <div
       class="flex items-center gap-2 mb-6 text-skin-accent text-sm uppercase tracking-wider print:text-black print:font-bold print:mb-1 print:text-xs"
     >
@@ -142,7 +143,7 @@
 {/if}
 
 <!-- Experience -->
-<section class="mb-10 print:mb-2">
+<section use:reveal class="mb-10 print:mb-2">
   <div
     class="flex items-center gap-2 mb-4 text-skin-accent text-sm uppercase tracking-wider print:text-black print:font-bold print:mb-2 print:text-xs"
   >
@@ -224,6 +225,7 @@
 <div class="hidden print:block border-t border-black my-4"></div>
 
 <div
+  use:reveal
   class="grid md:grid-cols-2 gap-10 print:grid-cols-2 print:gap-6 print:mb-0 print:mt-2"
 >
   <section>

--- a/site/src/lib/styles/app.css
+++ b/site/src/lib/styles/app.css
@@ -128,3 +128,13 @@ h1, h2, h3, h4, h5, h6 {
     animation: none;
   }
 }
+
+/* Never let a reveal-on-scroll section print blank: if it hasn't scrolled into
+   view when the page is printed, its inline opacity:0 would hide it on paper
+   (the printable resume in particular). Force revealed for print. */
+@media print {
+  .reveal-init {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}

--- a/site/src/routes/blog/+page.svelte
+++ b/site/src/routes/blog/+page.svelte
@@ -36,6 +36,7 @@
     </div>
 
     {#each posts as post, i}
+      {@const slug = post.route.split("/").pop()}
       <div use:reveal={{ delay: i * 50 }}>
       <a
         href={addVariant(post.route, variant)}
@@ -56,6 +57,7 @@
           {/if}
           <h2
             class="text-base text-skin-base group-hover:text-skin-accent font-bold transition-colors mb-1"
+            style:view-transition-name={"bt-" + slug}
           >
             {post.metadata.title}
           </h2>

--- a/site/src/routes/blog/[slug]/+page.svelte
+++ b/site/src/routes/blog/[slug]/+page.svelte
@@ -3,6 +3,7 @@
   import SEO from "$lib/components/SEO.svelte";
   import ImageGallery from "$lib/components/ImageGallery.svelte";
   import ProjectLinks from "$lib/components/ProjectLinks.svelte";
+  import { reveal } from "$lib/actions/reveal";
   import type { ContentMetadata } from "$lib/utils/content-loader";
 
   interface Props {
@@ -70,6 +71,23 @@
   />
 
   <article class="mx-auto max-w-4xl px-4">
+    <header class="mb-8 pb-6 border-b border-skin-border">
+      <h1
+        class="text-3xl md:text-4xl font-bold font-mono tracking-tight text-skin-base"
+        style:view-transition-name={"bt-" + page.params.slug}
+      >
+        {data.metadata.title}
+      </h1>
+      <p class="mt-2 font-mono text-sm text-skin-muted">
+        {new Date(data.metadata.date).toISOString().split("T")[0]}
+      </p>
+      {#if data.metadata.summary}
+        <p class="mt-3 text-skin-muted leading-relaxed max-w-2xl">
+          {data.metadata.summary}
+        </p>
+      {/if}
+    </header>
+
     <ImageGallery>
       <div class="prose prose-lg max-w-none prose-headings:font-mono">
         {@html data.html}
@@ -77,7 +95,9 @@
     </ImageGallery>
 
     {#if data.metadata.links?.length}
-      <ProjectLinks links={data.metadata.links} />
+      <div use:reveal>
+        <ProjectLinks links={data.metadata.links} />
+      </div>
     {/if}
   </article>
 {:else}

--- a/site/src/routes/projects/+page.svelte
+++ b/site/src/routes/projects/+page.svelte
@@ -32,6 +32,7 @@
 
   <div class="grid md:grid-cols-2 gap-6">
     {#each projects as p, i}
+      {@const slug = p.route.split("/").pop()}
       <div use:reveal={{ delay: i * 60 }}>
       <a
         href={addVariant(p.route, getVariant($page.url))}
@@ -51,6 +52,7 @@
           <div class="flex justify-between items-start mb-2">
             <h2
               class="font-bold text-lg font-mono text-skin-base group-hover:text-skin-accent transition-colors"
+              style:view-transition-name={"pt-" + slug}
             >
               {p.metadata.title}
             </h2>

--- a/site/src/routes/projects/[slug]/+page.svelte
+++ b/site/src/routes/projects/[slug]/+page.svelte
@@ -4,6 +4,7 @@
   import ImageGallery from "$lib/components/ImageGallery.svelte";
   import VisualArchive from "$lib/components/VisualArchive.svelte";
   import ProjectLinks from "$lib/components/ProjectLinks.svelte";
+  import { reveal } from "$lib/actions/reveal";
   import type { ContentMetadata } from "$lib/utils/content-loader";
 
   interface Props {
@@ -72,6 +73,23 @@
   />
 
   <article class="mx-auto max-w-4xl px-4">
+    <header class="mb-8 pb-6 border-b border-skin-border">
+      <h1
+        class="text-3xl md:text-4xl font-bold font-mono tracking-tight text-skin-base"
+        style:view-transition-name={"pt-" + page.params.slug}
+      >
+        {data.metadata.title}
+      </h1>
+      <p class="mt-2 font-mono text-sm text-skin-muted">
+        {data.metadata.period ?? new Date(data.metadata.date).getFullYear()}
+      </p>
+      {#if data.metadata.summary}
+        <p class="mt-3 text-skin-muted leading-relaxed max-w-2xl">
+          {data.metadata.summary}
+        </p>
+      {/if}
+    </header>
+
     <ImageGallery>
       <div class="prose prose-lg max-w-none prose-headings:font-mono">
         {@html data.html}
@@ -79,11 +97,15 @@
     </ImageGallery>
 
     {#if data.metadata.links?.length}
-      <ProjectLinks links={data.metadata.links} />
+      <div use:reveal>
+        <ProjectLinks links={data.metadata.links} />
+      </div>
     {/if}
 
     {#if data.metadata.visualArchive?.images?.length}
-      <VisualArchive images={data.metadata.visualArchive.images} />
+      <div use:reveal>
+        <VisualArchive images={data.metadata.visualArchive.images} />
+      </div>
     {/if}
   </article>
 {:else}


### PR DESCRIPTION
## What
Follow-up to the site-wide view transitions. Two things:

### 1. Shared-element morph (card title → detail heading)
- Each project card title carries `view-transition-name: pt-<slug>` (blog rows `bt-<slug>`), and the matching detail page's new `<h1>` carries the same name.
- On navigation the card title visually **morphs** into the page heading.
- Names are unique per list page (a duplicate would abort the transition — verified all 9 project names distinct).
- Universal across all 9 projects (only 2 have a featured image, so a title morph beats an image morph).

### 2. Detail pages get a real header (+ reveals)
- Project and blog detail pages had **no visible title** — they opened straight into `## The Problem`. They now render an `<h1>` title, date/period line, and summary at the top of the article. This doubles as the morph target.
- Reveal-on-scroll extended to project/blog detail auxiliary sections and to the **resume** sections (Summary, Skills, Experience, Education/Certs).

### Print safety (resume)
The resume is printable, so the reveal action now tags elements with `.reveal-init` and `app.css` forces them visible under `@media print`. Without this, an unscrolled section (inline `opacity:0`) would print blank.

## Verification (Playwright, preview build)
| Check | Result |
|---|---|
| All project/blog detail pages render a non-empty `<h1>` header + date + summary | PASS |
| All 9 project card `view-transition-name`s distinct; detail h1 matches its card | PASS |
| Click-through morph navigation: no console errors, back works | PASS |
| Resume sections settle at opacity 1 after scroll | PASS |
| **Unscrolled resume section stays opacity 1 under `@media print`** | PASS |
| Reduced motion: content visible immediately, `.reveal-init` not even applied | PASS |

`svelte-check` (0 errors), lint, and build all pass.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp