### PR TITLE
Fix lightbox positioning: reveal action containing-block bug

### DIFF
--- a/site/src/lib/actions/reveal.ts
+++ b/site/src/lib/actions/reveal.ts
@@ -34,6 +34,19 @@ export function reveal(node: HTMLElement, options: RevealOptions = {}) {
 				node.style.opacity = '1';
 				node.style.transform = 'none';
 				io.unobserve(node);
+				// Once revealed, drop the transform hint. `will-change: transform`
+				// (and the transient transform during the animation) establishes a
+				// containing block for any position:fixed descendant, which would
+				// otherwise offset fixed overlays like the image lightbox. Clearing
+				// it after the transition restores normal fixed positioning and is
+				// also good compositor hygiene.
+				node.addEventListener(
+					'transitionend',
+					() => {
+						node.style.willChange = 'auto';
+					},
+					{ once: true }
+				);
 			}
 		},
 		{ threshold: 0.1, rootMargin: '0px 0px -40px 0px' }

--- a/site/src/routes/projects/[slug]/+page.svelte
+++ b/site/src/routes/projects/[slug]/+page.svelte
@@ -103,9 +103,10 @@
     {/if}
 
     {#if data.metadata.visualArchive?.images?.length}
-      <div use:reveal>
-        <VisualArchive images={data.metadata.visualArchive.images} />
-      </div>
+      <!-- Not wrapped in use:reveal: VisualArchive renders a position:fixed
+           image lightbox, and a transforming/will-change ancestor would become
+           its containing block and offset the overlay. -->
+      <VisualArchive images={data.metadata.visualArchive.images} />
     {/if}
   </article>
 {:else}


### PR DESCRIPTION
## The bug
The `reveal` action set `will-change: transform` and never cleared it. `will-change: transform` (and the transient `transform` during the 500ms animation) establishes a **containing block for `position: fixed` descendants**. The image **lightbox** (`position: fixed`, rendered by `VisualArchive`) sat inside a `use:reveal` wrapper on the project detail page, so once opened it was positioned relative to that wrapper instead of the viewport — offset and unstable.

This showed up as a flaky `projects.spec.ts › lightbox closes when clicking backdrop` e2e failure ("element is not stable", 30s click timeout). It was latent from the earlier detail-reveals PR (#80).

## Fix
1. **`reveal.ts`**: clear `will-change` (→ `auto`) on `transitionend`, so no containing block lingers after the reveal. Also better compositor hygiene.
2. **Project detail page**: stop wrapping `VisualArchive` in `use:reveal` — a containing block still exists *during* the animation window, and that component hosts a fixed overlay. `ProjectLinks` (no overlay) keeps its reveal.

## Verification
All 9 Visual Archive e2e tests pass locally, including the previously-timing-out backdrop-click test (1.5s vs 30s timeout):

```
9 passed (4.3s)
```

`svelte-check` (0 errors), lint, build all pass.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp