### PR TITLE
Resolve the two accessibility warnings

### DIFF
--- a/site/src/lib/components/ExternalLinkModal.svelte
+++ b/site/src/lib/components/ExternalLinkModal.svelte
@@ -19,12 +19,16 @@
 {#if url}
   <div
     class="fixed inset-0 z-[60] bg-black/60 backdrop-blur-sm flex items-center justify-center p-4"
-    onclick={onCancel}
+    onclick={(e) => {
+      // Close only when the backdrop itself is clicked, not the dialog. Checking
+      // the event target avoids a stopPropagation handler on the dialog (which
+      // would be a click handler on a non-interactive element).
+      if (e.target === e.currentTarget) onCancel();
+    }}
     role="presentation"
   >
     <div
       class="bg-terminal-black border border-terminal-border rounded-lg shadow-2xl max-w-sm w-full font-mono"
-      onclick={(e) => e.stopPropagation()}
       role="dialog"
       aria-modal="true"
       aria-label="External link confirmation"

--- a/site/src/lib/components/Lightbox.svelte
+++ b/site/src/lib/components/Lightbox.svelte
@@ -106,6 +106,8 @@
     ontouchstart={handleTouchStart}
     ontouchmove={handleTouchMove}
     ontouchend={handleTouchEnd}
+    role="group"
+    aria-label="Image viewer, swipe left or right to change image"
   >
     <img
       src={images[index]}


### PR DESCRIPTION
Clears the two long-standing `svelte-check` a11y warnings; check is now **0 errors, 0 warnings**.

- **Lightbox.svelte** — the image swipe container had `ontouchstart/move/end` handlers but no ARIA role (`a11y_no_static_element_interactions`). Added `role="group"` + descriptive `aria-label`.
- **ExternalLinkModal.svelte** — the dialog used `onclick={(e) => e.stopPropagation()}` purely so backdrop clicks wouldn't close it, which tripped `a11y_click_events_have_key_events` (click handler on a non-interactive element). Removed it; the backdrop now closes only when it is itself the click target (`e.target === e.currentTarget`) — same behavior, no bogus handler.

`svelte-check` and lint clean.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp