### PR TITLE
Accessibility polish: contrast + ARIA semantics

### DIFF
--- a/site/src/lib/components/ChatInput.svelte
+++ b/site/src/lib/components/ChatInput.svelte
@@ -61,6 +61,7 @@
 		bind:value={inputValue}
 		onkeydown={handleKeyDown}
 		oninput={handleInput}
+		aria-label="Message to Brian's AI assistant"
 		placeholder="Ask about Brian's experience, skills, or paste a job description..."
 		class="flex-1 bg-transparent border border-terminal-green/30 rounded px-3 py-2 text-terminal-text font-mono text-sm resize-none focus:outline-none focus:border-terminal-green placeholder:text-terminal-text/50 disabled:opacity-50 disabled:cursor-not-allowed"
 		style="max-height: 200px; min-height: 56px;"

--- a/site/src/lib/components/Chatbot.svelte
+++ b/site/src/lib/components/Chatbot.svelte
@@ -175,7 +175,14 @@
 		</button>
 	{/snippet}
 
-	<div bind:this={chatContainer} class="flex-1 min-h-0 overflow-y-auto p-4 space-y-4">
+	<div
+		bind:this={chatContainer}
+		role="log"
+		aria-live="polite"
+		aria-relevant="additions"
+		aria-label="Chat conversation"
+		class="flex-1 min-h-0 overflow-y-auto p-4 space-y-4"
+	>
 		{#if messages.length === 0}
 			<div class="text-center text-terminal-text/70 py-12">
 				<p class="text-lg mb-4">👋 Hi! I'm Brian's AI assistant.</p>

--- a/site/src/lib/components/Footer.svelte
+++ b/site/src/lib/components/Footer.svelte
@@ -24,7 +24,7 @@
         {/if}
       </span>
       <span class="mx-2 opacity-50">|</span>
-      <span class="opacity-50 text-[10px]">v1.0.0</span>
+      <span class="opacity-70 text-[10px]">v1.0.0</span>
       <VariantSwitcher />
     </div>
 

--- a/site/src/lib/styles/app.css
+++ b/site/src/lib/styles/app.css
@@ -25,7 +25,7 @@
     /* Terminal Theme */
     --color-bg-page: 12, 12, 12; /* terminal-black */
     --color-text-base: 204, 204, 204; /* terminal-text */
-    --color-text-muted: 113, 113, 113; /* terminal-dim */
+    --color-text-muted: 140, 140, 140; /* terminal-dim, lifted to meet WCAG AA (4.5:1 on the dark page bg) */
     --color-border: 30, 30, 30; /* terminal-dark */
     --color-accent: 34, 197, 94; /* terminal-green (toned down) */
     --color-accent-contrast: 12, 12, 12;

--- a/site/src/routes/projects/+page.svelte
+++ b/site/src/routes/projects/+page.svelte
@@ -73,7 +73,7 @@
             <div class="flex flex-wrap gap-2">
               {#each p.metadata.tags as tag}
                 <span
-                  class="text-xs font-mono text-skin-accent/80 before:content-['#']"
+                  class="text-xs font-mono text-skin-accent before:content-['#']"
                 >
                   {tag}
                 </span>


### PR DESCRIPTION
Low-risk, high-value fixes from the accessibility audit.

## Contrast (WCAG AA)
- **Dark-theme muted text** (`app.css`): `--color-text-muted` 113 → 140 so nav links / footer links hit ~4.6:1 (was 4.01:1). Light + Catppuccin themes already passed.
- **Project tag badges**: drop `/80` opacity on the accent (was 3.39:1).
- **Footer version label**: `opacity-50` → `opacity-70` (was 2.59:1).

## ARIA semantics
- **ChatInput textarea**: add `aria-label` (was placeholder-only).
- **Chatbot message list**: `role="log" aria-live="polite"` so screen readers announce new assistant replies.

## Deferred (larger, tracked as follow-ups)
Lightbox + ExternalLinkModal focus traps, chatbot light-theme brand-color contrast (10 elements, needs theme-aware colors), and the Navbar nested-interactive terminal input. Called out so they're not lost.

`svelte-check` 0/0, lint clean.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp