### PR TITLE
Add focus traps to Lightbox and external-link modal

### DIFF
--- a/site/src/lib/actions/focusTrap.ts
+++ b/site/src/lib/actions/focusTrap.ts
@@ -1,0 +1,74 @@
+interface FocusTrapOptions {
+	/** Called when Escape is pressed while focus is inside the trap. */
+	onEscape?: () => void;
+}
+
+const FOCUSABLE =
+	'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Makes an element behave like an accessible modal dialog: on mount it moves
+ * focus inside (respecting an already-focused child or a [data-autofocus]
+ * target), traps Tab / Shift+Tab so focus cannot reach the page behind it, and
+ * on teardown restores focus to whatever was focused before it opened.
+ *
+ * This is the same trap the shared Modal component implements inline; extracted
+ * so bespoke dialogs (Lightbox, ExternalLinkModal) get identical behavior. The
+ * host element must be focusable (tabindex="-1") for the empty-dialog fallback.
+ *
+ * Escape is not handled here unless `onEscape` is passed, so dialogs that
+ * already close on Escape (e.g. Lightbox via svelte:window) can opt out.
+ */
+export function focusTrap(node: HTMLElement, options: FocusTrapOptions = {}) {
+	let opts = options;
+	const restoreFocus = document.activeElement as HTMLElement | null;
+
+	const raf = requestAnimationFrame(() => {
+		// Respect focus a child already claimed (e.g. an autofocus button).
+		if (node.contains(document.activeElement)) return;
+		const target =
+			node.querySelector<HTMLElement>('[data-autofocus]') ??
+			node.querySelector<HTMLElement>(FOCUSABLE) ??
+			node;
+		target?.focus();
+	});
+
+	function onKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			opts.onEscape?.();
+			return;
+		}
+		if (e.key !== 'Tab') return;
+
+		const nodes = Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+			(el) => el.offsetParent !== null
+		);
+		if (nodes.length === 0) {
+			e.preventDefault();
+			node.focus();
+			return;
+		}
+		const first = nodes[0];
+		const last = nodes[nodes.length - 1];
+		if (e.shiftKey && document.activeElement === first) {
+			e.preventDefault();
+			last.focus();
+		} else if (!e.shiftKey && document.activeElement === last) {
+			e.preventDefault();
+			first.focus();
+		}
+	}
+
+	node.addEventListener('keydown', onKeydown);
+
+	return {
+		update(newOptions: FocusTrapOptions = {}) {
+			opts = newOptions;
+		},
+		destroy() {
+			cancelAnimationFrame(raf);
+			node.removeEventListener('keydown', onKeydown);
+			restoreFocus?.focus?.();
+		}
+	};
+}

--- a/site/src/lib/components/ExternalLinkModal.svelte
+++ b/site/src/lib/components/ExternalLinkModal.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { focusTrap } from "$lib/actions/focusTrap";
+
   interface Props {
     url: string;
     onConfirm: () => void;
@@ -28,6 +30,7 @@
     role="presentation"
   >
     <div
+      use:focusTrap={{ onEscape: onCancel }}
       class="bg-terminal-black border border-terminal-border rounded-lg shadow-2xl max-w-sm w-full font-mono"
       role="dialog"
       aria-modal="true"

--- a/site/src/lib/components/Lightbox.svelte
+++ b/site/src/lib/components/Lightbox.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { X, ChevronLeft, ChevronRight } from "lucide-svelte";
   import { fade } from "svelte/transition";
+  import { focusTrap } from "$lib/actions/focusTrap";
 
   interface Props {
     images: string[];
@@ -66,6 +67,7 @@
 <svelte:window onkeydown={handleKeydown} />
 
 <div
+  use:focusTrap
   class="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/95 backdrop-blur-sm p-4"
   role="dialog"
   tabindex="-1"

--- a/site/src/lib/components/Lightbox.svelte
+++ b/site/src/lib/components/Lightbox.svelte
@@ -64,8 +64,6 @@
   }
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
-
 <div
   use:focusTrap
   class="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/95 backdrop-blur-sm p-4"


### PR DESCRIPTION
Both dialogs are bespoke (not built on the shared `Modal`), so they never trapped Tab or restored focus — a keyboard user could Tab out of the open lightbox onto the page behind it, and the external-link modal had no Escape handling.

## Change
- New reusable **`focusTrap` action** (`src/lib/actions/focusTrap.ts`) extracted from Modal's proven pattern: moves focus in on open (respecting `[data-autofocus]`/existing focus), wraps Tab/Shift+Tab, restores focus on close, optional `onEscape`.
- Applied to **Lightbox** (keeps its existing Escape) and **ExternalLinkModal** (gains Escape-to-cancel via `onEscape`).
- Fixed a double-step the trap exposed: the Lightbox handled keydown on both `svelte:window` and the dialog div, so once focus was trapped inside, ArrowLeft/Right fired twice. Consolidated to the dialog handler.

## Verification
Playwright (real keyboard) on both dialogs:
| Behavior | Lightbox | External-link modal |
|---|---|---|
| Focus moves in on open | PASS | PASS (Continue) |
| Tab trapped, wraps both directions | PASS | PASS |
| Focus restored to trigger on close | PASS | PASS |
| Escape closes (no navigation) | PASS | PASS (URL unchanged) |

All 9 Visual Archive e2e tests pass locally, including ArrowRight/ArrowLeft (now single-step) and backdrop-close. `svelte-check` 0 errors / 0 warnings, lint clean.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp