### PR TITLE
Lazy-load PostHog out of the initial bundle

### DIFF
--- a/site/scripts/validate-posthog.js
+++ b/site/scripts/validate-posthog.js
@@ -87,25 +87,36 @@ async function validateClientSideIntegration() {
   let passed = 0;
   let total = 0;
 
-  // Check layout.svelte for all PostHog integration
+  // PostHog is lazy-loaded: posthog-js is dynamically imported inside
+  // posthog-lazy.ts and the layout drives it through loadPostHog()/withPostHog().
   const layoutSveltePath = path.resolve('src/routes/+layout.svelte');
-  if (fs.existsSync(layoutSveltePath)) {
-    const layoutContent = fs.readFileSync(layoutSveltePath, 'utf-8');
+  const lazyPath = path.resolve('src/lib/utils/posthog-lazy.ts');
+  const layoutContent = fs.existsSync(layoutSveltePath)
+    ? fs.readFileSync(layoutSveltePath, 'utf-8')
+    : '';
+  const lazyContent = fs.existsSync(lazyPath) ? fs.readFileSync(lazyPath, 'utf-8') : '';
 
+  if (layoutContent) {
     total++;
-    if (layoutContent.includes("import posthog from") && layoutContent.includes("posthog-js")) {
+    if (lazyContent.includes("import('posthog-js')") || lazyContent.includes('import("posthog-js")')) {
+      success('posthog-js is dynamically imported in posthog-lazy.ts (lazy-loaded)');
+      passed++;
+    } else if (layoutContent.includes('posthog-js')) {
       success('posthog-js is imported in layout.svelte');
       passed++;
     } else {
-      error('posthog-js import missing in layout.svelte');
+      error('posthog-js import missing (expected dynamic import in posthog-lazy.ts)');
     }
 
     total++;
-    if (layoutContent.includes('posthog.init(')) {
+    if (layoutContent.includes('loadPostHog(') && lazyContent.includes('posthog.init(')) {
+      success('PostHog is initialized via loadPostHog() -> posthog.init()');
+      passed++;
+    } else if (layoutContent.includes('posthog.init(')) {
       success('posthog.init() is called in layout.svelte');
       passed++;
     } else {
-      error('posthog.init() call missing in layout.svelte');
+      error('PostHog initialization missing (expected loadPostHog() + posthog.init())');
     }
 
     total++;
@@ -117,11 +128,11 @@ async function validateClientSideIntegration() {
     }
 
     total++;
-    if (layoutContent.includes('posthog.capture(')) {
-      success('posthog.capture() is called for events');
+    if (layoutContent.includes('.capture(') || layoutContent.includes('withPostHog(')) {
+      success('Events are captured via withPostHog()/capture()');
       passed++;
     } else {
-      error('posthog.capture() call missing in layout.svelte');
+      error('capture() call missing in layout.svelte');
     }
 
     total++;

--- a/site/src/lib/components/ConnectBanner.svelte
+++ b/site/src/lib/components/ConnectBanner.svelte
@@ -2,7 +2,7 @@
   import { onMount } from "svelte";
   import { browser } from "$app/environment";
   import { page } from "$app/stores";
-  import posthog from "posthog-js";
+  import { trackEvent } from "$lib/utils/analytics";
   import { PUBLIC_POSTHOG_KEY } from "$env/static/public";
 
   interface Props {
@@ -86,7 +86,7 @@
         startTyping();
 
         if (PUBLIC_POSTHOG_KEY) {
-          posthog.capture("connect_banner_shown", {
+          trackEvent("connect_banner_shown", {
             page: $page.url.pathname,
             timeOnPage: SHOW_DELAY_MS / 1000
           });
@@ -111,7 +111,7 @@
     }
 
     if (browser && PUBLIC_POSTHOG_KEY) {
-      posthog.capture("connect_banner_dismissed", {
+      trackEvent("connect_banner_dismissed", {
         wasExpanded: expanded,
         daysUntilShowAgain: DISMISS_DURATION_DAYS
       });
@@ -127,13 +127,13 @@
     }
 
     if (browser && PUBLIC_POSTHOG_KEY) {
-      posthog.capture(expanded ? "connect_banner_expanded" : "connect_banner_collapsed");
+      trackEvent(expanded ? "connect_banner_expanded" : "connect_banner_collapsed");
     }
   }
 
   function handleFitFinderClick() {
     if (browser && PUBLIC_POSTHOG_KEY) {
-      posthog.capture("connect_banner_action", {
+      trackEvent("connect_banner_action", {
         action: "fit_finder"
       });
     }
@@ -142,7 +142,7 @@
 
   function handleChatClick() {
     if (browser && PUBLIC_POSTHOG_KEY) {
-      posthog.capture("connect_banner_action", {
+      trackEvent("connect_banner_action", {
         action: "chat"
       });
     }

--- a/site/src/lib/utils/analytics.ts
+++ b/site/src/lib/utils/analytics.ts
@@ -4,7 +4,7 @@
  */
 
 import { browser } from '$app/environment';
-import posthog from 'posthog-js';
+import { withPostHog } from './posthog-lazy';
 import { PUBLIC_POSTHOG_KEY } from '$env/static/public';
 
 /**
@@ -14,7 +14,7 @@ import { PUBLIC_POSTHOG_KEY } from '$env/static/public';
  */
 export function trackEvent(event: string, properties?: Record<string, unknown>): void {
   if (browser && PUBLIC_POSTHOG_KEY) {
-    posthog.capture(event, properties);
+    withPostHog((ph) => ph.capture(event, properties));
   }
 }
 
@@ -25,7 +25,7 @@ export function trackEvent(event: string, properties?: Record<string, unknown>):
  */
 export function identifyUser(userId: string, properties?: Record<string, unknown>): void {
   if (browser && PUBLIC_POSTHOG_KEY) {
-    posthog.identify(userId, properties);
+    withPostHog((ph) => ph.identify(userId, properties));
   }
 }
 
@@ -34,7 +34,7 @@ export function identifyUser(userId: string, properties?: Record<string, unknown
  */
 export function resetUser(): void {
   if (browser && PUBLIC_POSTHOG_KEY) {
-    posthog.reset();
+    withPostHog((ph) => ph.reset());
   }
 }
 

--- a/site/src/lib/utils/posthog-lazy.ts
+++ b/site/src/lib/utils/posthog-lazy.ts
@@ -1,0 +1,41 @@
+import type { PostHog, PostHogConfig } from 'posthog-js';
+
+/**
+ * Lazy PostHog loader. `posthog-js` is ~100 KB gzip and is not needed for first
+ * paint, so it's kept out of the initial bundle and only fetched (via dynamic
+ * import) once analytics actually starts. `import type` above is erased at
+ * build time, so it adds nothing to the bundle.
+ */
+
+let phPromise: Promise<PostHog | null> | null = null;
+
+/**
+ * Dynamically import and initialize PostHog exactly once. Repeated calls return
+ * the same in-flight/resolved promise. Resolves to null if the import fails.
+ */
+export function loadPostHog(
+	key: string,
+	options: Partial<PostHogConfig>
+): Promise<PostHog | null> {
+	if (phPromise) return phPromise;
+	phPromise = import('posthog-js')
+		.then(({ default: posthog }) => {
+			posthog.init(key, options);
+			return posthog;
+		})
+		.catch((err) => {
+			console.error('Failed to load PostHog', err);
+			return null;
+		});
+	return phPromise;
+}
+
+/**
+ * Run `fn` with the initialized PostHog once it's ready. No-op if PostHog was
+ * never loaded (e.g. no key configured), so callers don't need their own guard
+ * beyond deciding whether analytics is enabled at all.
+ */
+export function withPostHog(fn: (ph: PostHog) => void): void {
+	if (!phPromise) return;
+	phPromise.then((ph) => ph && fn(ph)).catch(() => {});
+}

--- a/site/src/lib/utils/web-vitals.ts
+++ b/site/src/lib/utils/web-vitals.ts
@@ -4,7 +4,7 @@
  */
 
 import { browser } from "$app/environment";
-import posthog from "posthog-js";
+import { withPostHog } from "./posthog-lazy";
 import { PUBLIC_POSTHOG_KEY } from "$env/static/public";
 import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB, type Metric } from "web-vitals";
 
@@ -13,14 +13,16 @@ import { onCLS, onFCP, onFID, onINP, onLCP, onTTFB, type Metric } from "web-vita
  */
 function sendToPostHog(metric: Metric): void {
   if (browser && PUBLIC_POSTHOG_KEY) {
-    posthog.capture("web_vital", {
-      metric_name: metric.name,
-      metric_value: metric.value,
-      metric_rating: metric.rating,
-      metric_delta: metric.delta,
-      metric_id: metric.id,
-      navigation_type: metric.navigationType,
-    });
+    withPostHog((ph) =>
+      ph.capture("web_vital", {
+        metric_name: metric.name,
+        metric_value: metric.value,
+        metric_rating: metric.rating,
+        metric_delta: metric.delta,
+        metric_id: metric.id,
+        navigation_type: metric.navigationType,
+      })
+    );
   }
 }
 

--- a/site/src/routes/+layout.svelte
+++ b/site/src/routes/+layout.svelte
@@ -14,7 +14,7 @@
   import { initWebVitals } from "$lib/utils/web-vitals";
   import { browser } from "$app/environment";
   import { beforeNavigate, afterNavigate, onNavigate } from "$app/navigation";
-  import posthog from "posthog-js";
+  import { loadPostHog, withPostHog } from "$lib/utils/posthog-lazy";
   import { PUBLIC_POSTHOG_KEY, PUBLIC_POSTHOG_HOST } from "$env/static/public";
   import ExternalLinkModal from "$lib/components/ExternalLinkModal.svelte";
 
@@ -158,11 +158,10 @@
 
     onMount(() => {
       if (PUBLIC_POSTHOG_KEY) {
-        console.log(
-          "Initializing PostHog with key starting:",
-          PUBLIC_POSTHOG_KEY.substring(0, 4),
-        );
-        posthog.init(PUBLIC_POSTHOG_KEY, {
+        // Lazy-load posthog-js (a heavy dep) off the critical path. loadPostHog
+        // sets its promise synchronously, so the withPostHog() calls below (and
+        // in navigation hooks / analytics) queue until it resolves.
+        loadPostHog(PUBLIC_POSTHOG_KEY, {
           api_host: PUBLIC_POSTHOG_HOST || "https://app.posthog.com",
           capture_pageview: false,
           capture_pageleave: false,
@@ -176,11 +175,10 @@
             ph.register({
               deployment_environment: deploymentEnv,
             });
-            console.log("PostHog loaded, env:", deploymentEnv);
           },
         });
         // Force capture initial pageview on mount to be sure
-        posthog.capture("$pageview");
+        withPostHog((ph) => ph.capture("$pageview"));
 
         // Initialize Web Vitals tracking
         initWebVitals();
@@ -189,7 +187,7 @@
       }
     });
 
-    beforeNavigate(() => posthog.capture("$pageleave"));
+    beforeNavigate(() => withPostHog((ph) => ph.capture("$pageleave")));
 
     // Track subsequent navigations
     let isInitial = true;
@@ -198,7 +196,7 @@
         isInitial = false;
         return; // Handled by onMount
       }
-      posthog.capture("$pageview");
+      withPostHog((ph) => ph.capture("$pageview"));
     });
 
     // Cross-page transitions via the native View Transitions API. Progressive


### PR DESCRIPTION
`posthog-js` (~100 KB gzip) was statically imported by the root layout, `analytics`, `web-vitals`, and `ConnectBanner`, so it sat in the root chunk (node 0) and shipped on every page's critical path — despite not being needed for first paint. This was the biggest remaining perf item from the audit.

## Change
- New **`posthog-lazy.ts`**: dynamically `import('posthog-js')` once on mount; `withPostHog(fn)` runs deferred `capture` calls when it's ready. `import type` keeps the types out of the bundle.
- Routed all four consumers through it: `+layout.svelte` (init + pageview/pageleave/pageview-on-nav), `analytics.ts` (`trackEvent`/`identifyUser`/`resetUser`), `web-vitals.ts`, and `ConnectBanner.svelte` (via the existing `trackEvent`).

## Result (measured on the build)
- Root layout chunk **302 KB → 136 KB** raw.
- `posthog-js` is now its own chunk (~172 KB) loaded **after hydration** via dynamic `import()`, with **no** `modulepreload`/`preload` link on the initial page.
- Same analytics behavior: identical init options, `deployment_environment` register, `$pageview`/`$pageleave`, and `web_vital` events.

`svelte-check` 0/0, lint + build clean.

⚠️ Local preview has no PostHog key, so the analytics path is inert locally — I'll spot-check on dev after deploy that events still fire.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp