### PR TITLE
Deflake the deploy gate: block on E2E, report-only for API smoke + AI evals

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -401,15 +401,29 @@ jobs:
           AI_EVAL_MIN_PASS_RATE: "0.95"
         continue-on-error: true
         run: pnpm run test:ai:evals
+      - name: Post-deploy check summary
+        if: always()
+        run: |
+          {
+            echo "### Dev post-deploy checks"
+            echo ""
+            echo "| Check | Gate | Result |"
+            echo "|---|---|---|"
+            echo "| Frontend E2E | blocking (rolls back on failure) | ${{ steps.smoke.outcome }} |"
+            echo "| API smoke | report-only | ${{ steps.smoke_api.outcome }} |"
+            echo "| AI behavior evals | report-only | ${{ steps.ai_evals.outcome }} |"
+            echo ""
+            echo "_API health is independently gated + rolled back by the deploy-functions-dev job. Report-only checks surface regressions without rolling back a working frontend._"
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload dev build artifact (Verified)
-        if: steps.smoke.outcome == 'success' && steps.smoke_api.outcome == 'success' && steps.ai_evals.outcome == 'success'
+        if: steps.smoke.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: build-artifact-dev
           path: site/build/
           retention-days: 14
       - name: Tag image as dev-stable
-        if: steps.smoke.outcome == 'success' && steps.smoke_api.outcome == 'success' && steps.ai_evals.outcome == 'success'
+        if: steps.smoke.outcome == 'success'
         env:
           REGION: ${{ secrets.GCP_REGION }}
           PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
@@ -418,12 +432,12 @@ jobs:
           IMAGE="${IMAGE:-${REGION}-docker.pkg.dev/${PROJECT_ID}/site-functions/api:${GITHUB_SHA:0:8}}"
           gcloud artifacts docker tags add "$IMAGE" "${REGION}-docker.pkg.dev/${PROJECT_ID}/site-functions/api:dev-stable"
       - name: Rollback on failure
-        if: (steps.smoke.outcome == 'failure' || steps.smoke_api.outcome == 'failure' || steps.ai_evals.outcome == 'failure') && steps.last_successful.outputs.run_id != 'none'
+        if: steps.smoke.outcome == 'failure' && steps.last_successful.outputs.run_id != 'none'
         env:
           LAST_RUN_ID: ${{ steps.last_successful.outputs.run_id }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo "❌ Smoke tests failed, rolling back dev to run $LAST_RUN_ID..."
+          echo "❌ Frontend E2E tests failed, rolling back dev to run $LAST_RUN_ID..."
           rm -rf site/build && gh run download $LAST_RUN_ID -n build-artifact-dev --dir site/build/
 
           # Upload with proper cache headers
@@ -442,8 +456,8 @@ jobs:
           gcloud storage rsync site/build/ gs://dev.briananderson.xyz/ --recursive --delete-unmatched-destination-objects --cache-control="public, max-age=60, must-revalidate"
           echo "Rollback complete."
           exit 1
-      - name: Fail if smoke tests failed
-        if: steps.smoke.outcome == 'failure' || steps.smoke_api.outcome == 'failure' || steps.ai_evals.outcome == 'failure'
+      - name: Fail if frontend E2E tests failed
+        if: steps.smoke.outcome == 'failure'
         run: exit 1
 
   deploy-prod:
@@ -552,15 +566,28 @@ jobs:
           SMOKE_TEST: 'true'
         continue-on-error: true
         run: pnpm run test:api
+      - name: Post-deploy check summary
+        if: always()
+        run: |
+          {
+            echo "### Prod post-deploy checks"
+            echo ""
+            echo "| Check | Gate | Result |"
+            echo "|---|---|---|"
+            echo "| Frontend E2E | blocking (rolls back on failure) | ${{ steps.smoke.outcome }} |"
+            echo "| API smoke | report-only | ${{ steps.smoke_api.outcome }} |"
+            echo ""
+            echo "_API health is independently gated + rolled back by the deploy-functions-prod job._"
+          } >> "$GITHUB_STEP_SUMMARY"
       - name: Upload prod build artifact (Verified)
-        if: steps.smoke.outcome == 'success' && steps.smoke_api.outcome == 'success'
+        if: steps.smoke.outcome == 'success'
         uses: actions/upload-artifact@v7
         with:
           name: build-artifact-prod
           path: site/build/
           retention-days: 30
       - name: Tag image as prod-stable
-        if: steps.smoke.outcome == 'success' && steps.smoke_api.outcome == 'success'
+        if: steps.smoke.outcome == 'success'
         env:
           REGION: ${{ secrets.GCP_REGION }}
           PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
@@ -569,12 +596,12 @@ jobs:
           IMAGE="${IMAGE:-${REGION}-docker.pkg.dev/${PROJECT_ID}/site-functions/api:${GITHUB_SHA:0:8}}"
           gcloud artifacts docker tags add "$IMAGE" "${REGION}-docker.pkg.dev/${PROJECT_ID}/site-functions/api:prod-stable"
       - name: Rollback on failure
-        if: (steps.smoke.outcome == 'failure' || steps.smoke_api.outcome == 'failure') && steps.last_successful.outputs.run_id != 'none'
+        if: steps.smoke.outcome == 'failure' && steps.last_successful.outputs.run_id != 'none'
         env:
           LAST_RUN_ID: ${{ steps.last_successful.outputs.run_id }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo "❌ Smoke tests failed, rolling back prod to run $LAST_RUN_ID..."
+          echo "❌ Frontend E2E tests failed, rolling back prod to run $LAST_RUN_ID..."
           rm -rf site/build && gh run download $LAST_RUN_ID -n build-artifact-prod --dir site/build/
 
           # Upload with proper cache headers
@@ -593,11 +620,11 @@ jobs:
           gcloud storage rsync site/build/ gs://briananderson.xyz/ --recursive --delete-unmatched-destination-objects --cache-control="public, max-age=3600, must-revalidate"
           echo "Rollback complete."
           exit 1
-      - name: Fail if smoke tests failed
-        if: steps.smoke.outcome == 'failure' || steps.smoke_api.outcome == 'failure'
+      - name: Fail if frontend E2E tests failed
+        if: steps.smoke.outcome == 'failure'
         run: exit 1
       - name: Warn if no rollback target
-        if: (steps.smoke.outcome == 'failure' || steps.smoke_api.outcome == 'failure') && steps.last_successful.outputs.run_id == 'none'
+        if: steps.smoke.outcome == 'failure' && steps.last_successful.outputs.run_id == 'none'
         run: |
           echo "⚠️  Smoke tests failed but no previous successful prod deployment found for rollback."
           echo "This is the first prod deployment - manual intervention may be required."

--- a/site/scripts/validate-api-endpoints.js
+++ b/site/scripts/validate-api-endpoints.js
@@ -47,7 +47,9 @@ async function validateChatEndpoint() {
   try {
     // Test 1: Basic chat request
     console.log('Test 1: Basic question about AWS...');
-    const response1 = await fetch(endpoint, {
+    // Use smokeFetch so a cold start / transient 5xx retries instead of
+    // failing the whole smoke run (the fit-finder primary call already does).
+    const response1 = await smokeFetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({


### PR DESCRIPTION
## Problem
The frontend deploy (`deploy-dev` / `deploy-prod`) rolled back the static site if **any** of E2E, API smoke, or AI evals failed. But:
- **API health is already gated independently** by the `deploy-functions-{dev,prod}` job (a 5-retry HTTP smoke that rolls back Cloud Run on its own).
- So the frontend job's **API smoke + AI evals were redundant coupling** — and they're the nondeterministic ones (live Gemini, LLM-judged). A cold-start blip or a flaky eval rolled back a perfectly good frontend. This silently hit ~half of recent deploys (#84, #87, #89), so dev kept lagging `main`.

E2E, by contrast, is deterministic and already retries 2× in CI.

## Fix (gate on deterministic, observe nondeterministic)
1. **Frontend rollback / verified-artifact / fail gate on E2E outcome only** (dev + prod). A flaky API/eval can't roll back the frontend anymore.
2. **API smoke + AI evals still run as report-only** (`continue-on-error`) and their results go to the **GitHub step summary**, so regressions stay visible.
3. **Hardened API smoke**: the chat primary request now uses the existing `smokeFetch` retry wrapper (the fit-finder call already did), so a transient 5xx / cold start retries instead of failing.

API health is still enforced (functions job); the frontend is still gated by E2E (retried). Real breakage is caught; nondeterministic flakiness no longer rolls back working code.

## Verification
- Workflow YAML parses; **no gate `if:` condition references `smoke_api`/`ai_evals`** (grep-confirmed).
- Both checks still run (report-only) and write a step summary.
- Hardened API smoke passes **13/13 against the live dev API** (exit 0).
- Post-merge: I'll watch the dev deploy succeed and confirm the summary renders.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp