### PR TITLE
Gate manual prod promotion on AI-behavior evals (no CI secret)

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -209,9 +209,50 @@ jobs:
           echo "Cloud Run rollback complete."
           exit 1
 
+  # Blocking AI-behavior gate on the manual prod promotion. Runs the eval suite
+  # against the just-deployed api-dev (same artifacts about to be promoted to
+  # prod), using the deployed service's own Gemini key — no CI secret. Prod only
+  # proceeds if AI behavior still passes at >=95%. Dev deploys are unaffected:
+  # this job only runs when deploy_prod=true, and the dev-deploy eval stays
+  # report-only. A single nondeterministic miss is absorbed by the runner's
+  # retry-failing-once pass, so only a real regression blocks prod.
+  ai-evals-prod-gate:
+    name: AI evals (prod promotion gate)
+    runs-on: ubuntu-latest
+    needs: [deploy-dev]
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_prod == 'true'
+    steps:
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: site/pnpm-lock.yaml
+      - name: Install deps
+        working-directory: site
+        run: pnpm i --frozen-lockfile
+      - name: Run AI behavior evals against dev (blocking)
+        working-directory: site
+        env:
+          AI_EVAL_BASE_URL: https://api-dev.briananderson.xyz
+          AI_EVAL_MIN_PASS_RATE: '0.95'
+          AI_EVAL_REPORT_PATH: artifacts/ai-evals-prod-gate.json
+        run: pnpm run test:ai:evals
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ai-eval-report-prod-gate
+          path: site/artifacts/ai-evals-prod-gate.json
+          if-no-files-found: ignore
+          retention-days: 14
+
   deploy-functions-prod:
     runs-on: ubuntu-latest
-    needs: [build-functions, deploy-dev]
+    needs: [build-functions, deploy-dev, ai-evals-prod-gate]
     environment: prod
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_prod == 'true'
     steps:

--- a/site/scripts/run-ai-evals.js
+++ b/site/scripts/run-ai-evals.js
@@ -415,7 +415,8 @@ async function runJudgeAssertion(assertion, context) {
   throw new Error(`Unsupported judge provider: ${judgeProvider}`);
 }
 
-async function runConfig(configPath) {
+async function runConfig(configPath, opts = {}) {
+  const onlyDescriptions = opts.only || null;
   const fullPath = path.resolve(configPath);
   const configDir = path.dirname(fullPath);
   const config = yaml.load(fs.readFileSync(fullPath, "utf-8"));
@@ -437,6 +438,9 @@ async function runConfig(configPath) {
 
   const tests = [];
   for (const testCase of config.tests || []) {
+    if (onlyDescriptions && !onlyDescriptions.has(testCase.description)) {
+      continue;
+    }
     total++;
     try {
       const vars = testCase.vars || {};
@@ -593,6 +597,43 @@ async function main() {
     });
   }
 
+  // Retry pass: a live LLM can fail a check on a single nondeterministic
+  // sample. Re-run only the failed cases once; a case that now passes is
+  // counted as passed. A real (deterministic) regression fails both times and
+  // still blocks. Enabled by default; set AI_EVAL_RETRY_FAILED=false to skip.
+  const retryEnabled = process.env.AI_EVAL_RETRY_FAILED !== "false";
+  let retriedTotal = 0;
+  let recoveredTotal = 0;
+  if (retryEnabled) {
+    for (const config of report.configs) {
+      const failed = config.tests.filter((test) => !test.passed);
+      if (failed.length === 0) {
+        continue;
+      }
+      const only = new Set(failed.map((test) => test.description));
+      retriedTotal += only.size;
+      warn(`Retrying ${only.size} failed case(s) in ${path.basename(config.path)} once...`);
+      const retry = await runConfig(config.path, { only });
+      for (const retriedTest of retry.tests) {
+        if (!retriedTest.passed) {
+          continue;
+        }
+        const original = config.tests.find((test) => test.description === retriedTest.description);
+        if (original && !original.passed) {
+          original.passed = true;
+          original.assertions = retriedTest.assertions;
+          original.recoveredOnRetry = true;
+          config.passed += 1;
+          totalPassed += 1;
+          recoveredTotal += 1;
+        }
+      }
+    }
+    if (retriedTotal > 0) {
+      info(`Retry pass: recovered ${recoveredTotal}/${retriedTotal} case(s) on second attempt.`);
+    }
+  }
+
   info(`AI eval summary: ${totalPassed}/${totalTests}`);
   info(`Hard checks: ${totalHardPassed}/${totalHardTests}`);
   if (totalJudgeTests > 0 || totalJudgeSkipped > 0) {
@@ -602,8 +643,12 @@ async function main() {
   appendStepSummary([
     "## AI Eval Summary",
     `- Endpoint base URL: \`${report.endpointBaseUrl}\``,
+    `- Pass rate: \`${totalPassed}/${totalTests}\``,
     `- Hard checks: \`${totalHardPassed}/${totalHardTests}\``,
     `- Judge checks: \`${totalJudgePassed}/${totalJudgeTests}\` passed, \`${totalJudgeSkipped}\` skipped`,
+    ...(retriedTotal > 0
+      ? [`- Retry pass: recovered \`${recoveredTotal}/${retriedTotal}\` flaky case(s) on second attempt`]
+      : []),
     `- Judge provider: \`${judgeProvider || "none"}\``,
     `- Judge model: \`${judgeModel || "none"}\``,
   ]);


### PR DESCRIPTION
## What
Restores AI-eval enforcement at the **prod-promotion boundary**, reusing the already-deployed dev API. No CI Gemini secret, no nightly cron, no deploy flakiness.

## Why here
- The evals test the **model's behavior**, which lives behind the deployed API. Pointing at the real `api-dev` needs **no secret** (it has its own Gemini key).
- The dev deploy already runs the suite against `api-dev` report-only, and it **passes 26/26**.
- Prod is a **manual** promotion, so gating it there costs one eval run only when you intentionally ship, at the moment it matters.

## Change
- New **`ai-evals-prod-gate`** job: runs the eval suite against `api-dev` at `AI_EVAL_MIN_PASS_RATE=0.95`, **blocking**, only on `deploy_prod=true`.
- `deploy-functions-prod` now `needs: [build-functions, deploy-dev, ai-evals-prod-gate]`, so **prod only ships if AI behavior still passes ≥95%**.
- Gates `api-dev` (mirrors the artifacts about to be promoted), so it never touches prod's own 20/15min rate limit.
- **Dev deploys unchanged**: the gate only runs on prod promotion, and the dev-deploy eval stays report-only, so a flaky eval can't block or roll back dev (preserves the earlier deflake fix). A bad prompt can reach dev, but is blocked from prod.
- **`run-ai-evals.js` retry-failing-once**: a case that fails on a single nondeterministic sample is re-run once; only a deterministic regression fails twice and blocks. Recovered cases show in the step summary. No-op on a fully passing run.

## Verification
- Runner syntax + eslint clean; workflow YAML valid.
- Job graph: `deploy-dev → ai-evals-prod-gate → deploy-functions-prod → deploy-prod`.
- The gate runs the **identical eval command already proven to pass 26/26** against `api-dev`; the retry pass is inert unless a case fails.
- The gate itself is exercised on the next real manual prod promotion (it can't run on this PR, since the deploy workflow is push/dispatch-only).

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp