### PR TITLE
Surface two original OSS tools as project pages (boo, mqtt-recorder)

### DIFF
--- a/site/content/projects/boo-agent-scheduler.md
+++ b/site/content/projects/boo-agent-scheduler.md
@@ -1,0 +1,31 @@
+---
+title: "Boo: A Scheduler Daemon for AI Agents"
+date: 2026-03-09
+period: "2026 – Present"
+summary: "A cross-platform scheduler daemon, written in Rust, that fires AI agent prompts on cron schedules. Heartbeat-based, it survives sleep/wake cycles and catches up on runs it missed while the machine was off."
+tags: ["AgenticAI", "Rust", "Automation", "Builder", "SideProject", "OpenSource"]
+keywords: ["boo", "agent-scheduler", "cron", "rust", "kiro-cli", "ai-automation", "daemon"]
+showTableOfContents: true
+links:
+  - label: "GitHub Repository"
+    url: "https://github.com/briananderson1222/boo"
+    type: "github"
+  - label: "Releases"
+    url: "https://github.com/briananderson1222/boo/releases"
+    type: "website"
+---
+
+## The Goal
+
+I wanted my AI agents to do things while I was not sitting in front of them. A morning brief before the workday, an inbox triage every 30 minutes, a reminder that fires once and then deletes itself. Plain cron can run a command, but it has no idea an agent exists: no notion of which agent or model to use, no capture of the response, no recovery when the laptop was asleep at 9am. Boo is the missing layer between a schedule and an agent.
+
+## What I Built
+
+- **A Rust daemon with three schedule types:** recurring `cron` expressions, one-shot `at` times (including natural language like "tomorrow 9am", parsed via the agent CLI with confirmation), and fixed `every` intervals.
+- **Agent-aware jobs:** each job can target a specific agent and model, run in its own working directory, and enforce a timeout that kills the process group cleanly if it overruns.
+- **Heartbeat with missed-run recovery:** the daemon tracks a heartbeat so it can tell the difference between "nothing was scheduled" and "the machine was asleep", then catches up on runs it missed instead of silently dropping them.
+- **A full operator surface:** desktop notifications, run history and statistics over 24h/7d/30d windows, live view of active runs with PID and elapsed time, resume of an interactive session to follow up on a scheduled run, and install/uninstall as an auto-start service.
+
+## What It Demonstrates
+
+Boo is systems programming in service of agentic workflows: process supervision, signal handling, cron and interval math, persistence across reboots, and OS integration for notifications and auto-start, all in Rust. It has shipped through five tagged releases (v0.5.1 at last count) and is the scheduler I actually use to run my own proactive AI tasks. It is the concrete answer to a question I care about: what does it take to make an agent reliable enough to trust unattended?

--- a/site/content/projects/mqtt-recorder.md
+++ b/site/content/projects/mqtt-recorder.md
@@ -1,0 +1,31 @@
+---
+title: "mqtt-recorder: Record, Replay, and Mirror MQTT"
+date: 2026-02-13
+period: "2026"
+summary: "A Rust command-line tool for recording, replaying, and mirroring MQTT message streams, with an embedded broker, an interactive terminal dashboard, and independent verification of mirrored traffic."
+tags: ["Rust", "SystemsEngineering", "IoT", "Builder", "SideProject", "OpenSource"]
+keywords: ["mqtt", "mqtt-recorder", "rust", "iot", "message-broker", "record-replay", "tui"]
+showTableOfContents: true
+links:
+  - label: "GitHub Repository"
+    url: "https://github.com/briananderson1222/mqtt-recorder"
+    type: "github"
+  - label: "Releases"
+    url: "https://github.com/briananderson1222/mqtt-recorder/releases"
+    type: "website"
+---
+
+## The Goal
+
+Working with MQTT systems, I kept wanting the equivalent of a DVR for a message bus: capture what a broker is publishing, replay it later with the original timing, and mirror a live broker into a local one so I could develop against real traffic without touching production. The existing options were either language-specific libraries or scripts that fell apart on binary payloads and protocol differences. I wanted one fast, self-contained binary that did all of it.
+
+## What I Built
+
+- **Four operating modes:** record broker traffic to CSV, replay it with timing preserved (optionally looping), mirror an external broker into an embedded one in real time, and run a standalone embedded broker on its own.
+- **An interactive TUI:** a real-time terminal dashboard to drive recording, mirroring, and playback, with a live audit log annotated by area and severity.
+- **Correctness under messy inputs:** automatic binary detection with base64 encoding for safe CSV storage, plus CSV validation and repair for files that got corrupted.
+- **Protocol and transport depth:** MQTT v3.1.1 and v5 support (v5 by default), TLS with certificate authentication, wildcard and file-driven topic filtering, periodic health-check monitoring, and a verify mode that independently compares source messages against the embedded broker's output.
+
+## What It Demonstrates
+
+This one is deliberately not an AI project. It is proof of the systems-engineering half of how I build: an embedded broker, real-time stream handling, protocol version negotiation, TLS, binary-safe serialization, and a terminal UI, packaged as a single cross-platform Rust binary with CI and prebuilt releases for Linux, macOS, and Windows. Good agentic systems rest on this kind of foundation, and mqtt-recorder is where I keep that muscle honest.


### PR DESCRIPTION
## What
Adds case-study project pages for two of my original public repos, so the builder positioning is backed by visible, shippable code instead of resting on repos the site never mentioned.

## Which, and why these two
I evaluated the candidates and **filtered out forks** (everything-claude-code, skills, the-library, bowser are forks, not original work). The genuine, mature, original tools:

- **boo** (Rust): scheduler daemon that fires AI agent prompts on cron schedules; heartbeat-based missed-run recovery, agent/model targeting, desktop notifications, auto-start service. **78 commits, 5 releases.** On-brand for agentic systems.
- **mqtt-recorder** (Rust): record/replay/mirror MQTT with an embedded broker, interactive TUI, TLS, MQTT v5, independent verify mode. **39 commits, 3 releases, CI, prebuilt binaries.** Deliberately *not* AI, it shows the systems-engineering range underneath.

**oar was evaluated and held** (least mature at 15 commits; direction unsettled, possibly folding into knowledge-kit). **Stallion** already links to the correct `work-agent` repo, so no mismatch fix was needed.

## Framing
Each page uses the existing projects schema (Goal / What I Built / What It Demonstrates + repo & release links), written honestly for OSS tools rather than with invented business metrics.

## Verification
- No em dashes; `svelte-check` 0/0; `eslint` clean
- Both prerender with correct canonical (no `sveltekit-prerender` leak) and titles
- Present in `sitemap.xml`; `.md` mirrors generated; indexed in `content-index.json` (so the chatbot / Fit Finder can cite them)

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp