### PR TITLE
Add /now and /uses pages

### DIFF
--- a/site/content/now.yaml
+++ b/site/content/now.yaml
@@ -1,0 +1,35 @@
+title: "Now"
+description: "What I'm focused on right now."
+updated: "2026-07-03"
+intro: >
+  This is a now page: a snapshot of what has my attention at the moment,
+  rather than a resume of everything I have done. It goes stale on purpose,
+  and I update it when the focus shifts.
+focus:
+  - heading: "Industrial Agentic AI at AWS"
+    body: >
+      My day job is agentic AI and cloud-native work with AWS customers. Most
+      of my energy goes to ProveIT, a manufacturing demo that turns real-time
+      plant data (a Unified Namespace over MQTT into a time-series store) into
+      an agent layer on Bedrock and AgentCore that flags anomalies and walks
+      operators through SOP-driven troubleshooting in plain language.
+  - heading: "Making this site the best it can be"
+    body: >
+      This site is a live project, not a brochure. Lately that has meant an
+      AI chatbot and Fit Finder grounded in my real work, promptfoo evals that
+      gate the chatbot's behavior, and hardening the deploy pipeline so a flaky
+      run can't ship or roll back the wrong thing. If you are an agent reading
+      this, start at /llms.txt.
+  - heading: "Building small, sharp tools"
+    body: >
+      On the side I build in Rust and Python to keep the systems muscle honest:
+      boo, a scheduler daemon that fires AI agent prompts on cron and recovers
+      missed runs, and mqtt-recorder, a record/replay/mirror tool for MQTT.
+      CampFit, a Denver kids-camp discovery platform, is my current full-stack
+      side project.
+  - heading: "Agentic developer workflows"
+    body: >
+      I keep refining how I work with AI as a systems-thinking partner rather
+      than an autocomplete layer: structured Kiro workflows for ideation,
+      implementation, and verification, evaluated with promptfoo before I rely
+      on them.

--- a/site/src/lib/components/Footer.svelte
+++ b/site/src/lib/components/Footer.svelte
@@ -29,6 +29,8 @@
     </div>
 
     <div class="flex items-center gap-4">
+      <a href="/now/" class="hover:text-skin-accent transition-colors">[ now ]</a>
+      <a href="/uses/" class="hover:text-skin-accent transition-colors">[ uses ]</a>
       <a
         href="https://github.com/briananderson1222"
         target="_blank"

--- a/site/src/routes/now/+page.server.ts
+++ b/site/src/routes/now/+page.server.ts
@@ -1,0 +1,28 @@
+import fs from "fs";
+import yaml from "js-yaml";
+import path from "path";
+
+export const prerender = true;
+
+interface FocusItem {
+  heading: string;
+  body: string;
+}
+
+interface NowFile {
+  title: string;
+  description: string;
+  updated: string;
+  intro: string;
+  focus: FocusItem[];
+}
+
+// /now is the nownownow.com convention: a dated snapshot of current focus.
+// Content lives in content/now.yaml so it can be updated without code changes.
+export const load = async () => {
+  const filePath = path.resolve("content/now.yaml");
+  const file = fs.readFileSync(filePath, "utf-8");
+  const now = yaml.load(file) as NowFile;
+
+  return { now };
+};

--- a/site/src/routes/now/+page.svelte
+++ b/site/src/routes/now/+page.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+  import SEO from "$lib/components/SEO.svelte";
+  import { getCanonicalUrl } from "$lib/utils/variantLink";
+
+  interface FocusItem {
+    heading: string;
+    body: string;
+  }
+  interface Props {
+    data: {
+      now: {
+        title: string;
+        description: string;
+        updated: string;
+        intro: string;
+        focus: FocusItem[];
+      };
+    };
+  }
+
+  let { data }: Props = $props();
+
+  const updatedLabel = $derived(
+    new Date(`${data.now.updated}T00:00:00Z`).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      timeZone: "UTC",
+    })
+  );
+</script>
+
+<SEO
+  title="Now | Brian Anderson"
+  description={data.now.description}
+  canonical={getCanonicalUrl("/now/")}
+/>
+
+<section class="mx-auto max-w-3xl px-4 py-16">
+  <div class="flex items-center gap-2 mb-4 font-mono text-skin-accent">
+    <span>></span>
+    <h1 class="text-3xl font-bold tracking-tight">./now</h1>
+  </div>
+  <p class="font-mono text-skin-muted mb-2 border-l-2 border-skin-border pl-4 leading-relaxed">
+    {data.now.intro}
+  </p>
+  <p class="font-mono text-xs text-skin-muted/70 mb-12 pl-4">
+    Last updated {updatedLabel}
+  </p>
+
+  <div class="space-y-10">
+    {#each data.now.focus as item}
+      <div class="border-l-2 border-skin-border pl-4 hover:border-skin-accent transition-colors group">
+        <h2 class="font-mono font-bold text-skin-base mb-2 group-hover:text-skin-accent transition-colors">
+          {item.heading}
+        </h2>
+        <p class="font-mono text-sm text-skin-muted leading-relaxed">{item.body}</p>
+      </div>
+    {/each}
+  </div>
+
+  <p class="font-mono text-xs text-skin-muted/70 mt-14 pt-6 border-t border-skin-border">
+    Inspired by <a href="https://nownownow.com/about" target="_blank" rel="noreferrer" class="text-skin-accent hover:underline">nownownow.com</a>.
+    See also <a href="/uses/" class="text-skin-accent hover:underline">/uses</a>.
+  </p>
+</section>

--- a/site/src/routes/sitemap.xml/+server.ts
+++ b/site/src/routes/sitemap.xml/+server.ts
@@ -5,7 +5,7 @@ export const prerender = true;
 const site = PUBLIC_SITE_URL;
 export const GET = async () => {
   const buildDate = new Date().toISOString().split('T')[0];
-  const staticPages = ['/', '/blog', '/projects', '/interests', '/following', '/resume', '/ops', '/builder', '/ops/resume', '/builder/resume'];
+  const staticPages = ['/', '/blog', '/projects', '/interests', '/now', '/uses', '/following', '/resume', '/ops', '/builder', '/ops/resume', '/builder/resume'];
   const aiPages = ['/llms.txt', '/resume.json'];
   const mBlog = import.meta.glob('/content/blog/**/*.md', { eager: true });
   const mProj = import.meta.glob('/content/projects/**/*.md', { eager: true });

--- a/site/src/routes/uses/+page.server.ts
+++ b/site/src/routes/uses/+page.server.ts
@@ -1,0 +1,43 @@
+import fs from "fs";
+import yaml from "js-yaml";
+import path from "path";
+
+export const prerender = true;
+
+interface SetupItem {
+  label: string;
+  value: string;
+}
+
+interface SetupCategory {
+  name: string;
+  items: SetupItem[];
+}
+
+interface Section {
+  id: string;
+  name: string;
+  description?: string;
+  type: string;
+  categories?: SetupCategory[];
+}
+
+interface InterestsFile {
+  sections: Section[];
+}
+
+// /uses is the well-known convention (uses.tech) for "what hardware and
+// software I use". Rather than maintain a second copy, it reads the same
+// `setup` section that powers /interests, so the two never drift.
+export const load = async () => {
+  const filePath = path.resolve("content/interests.yaml");
+  const file = fs.readFileSync(filePath, "utf-8");
+  const data = yaml.load(file) as InterestsFile;
+  const setup = data.sections?.find((s) => s.id === "setup");
+
+  return {
+    setup: setup
+      ? { name: setup.name, description: setup.description, categories: setup.categories ?? [] }
+      : null,
+  };
+};

--- a/site/src/routes/uses/+page.svelte
+++ b/site/src/routes/uses/+page.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import SEO from "$lib/components/SEO.svelte";
+  import { getCanonicalUrl } from "$lib/utils/variantLink";
+
+  interface SetupItem {
+    label: string;
+    value: string;
+  }
+  interface SetupCategory {
+    name: string;
+    items: SetupItem[];
+  }
+  interface Props {
+    data: {
+      setup: { name: string; description?: string; categories: SetupCategory[] } | null;
+    };
+  }
+
+  let { data }: Props = $props();
+</script>
+
+<SEO
+  title="Uses | Brian Anderson"
+  description="The hardware, software, and tools I use daily to build."
+  canonical={getCanonicalUrl("/uses/")}
+/>
+
+<section class="mx-auto max-w-4xl px-4 py-16">
+  <div class="flex items-center gap-2 mb-4 font-mono text-skin-accent">
+    <span>></span>
+    <h1 class="text-3xl font-bold tracking-tight">./uses</h1>
+  </div>
+  <p class="font-mono text-skin-muted mb-12 border-l-2 border-skin-border pl-4 leading-relaxed">
+    The hardware, software, and tools I rely on daily. This is a
+    <a href="https://uses.tech" target="_blank" rel="noreferrer" class="text-skin-accent hover:underline">/uses</a>
+    page: the same setup that lives on my
+    <a href="/interests/#setup" class="text-skin-accent hover:underline">interests</a> page.
+  </p>
+
+  {#if data.setup}
+    <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {#each data.setup.categories as category}
+        <div class="border border-skin-border rounded-lg p-5 bg-skin-base/5 hover:border-skin-accent/50 transition-colors">
+          <h2 class="font-mono text-xs font-bold uppercase tracking-wider text-skin-muted mb-4">
+            {category.name}
+          </h2>
+          <dl class="space-y-2">
+            {#each category.items as item}
+              <div class="flex flex-col gap-0.5">
+                <dt class="font-mono text-xs text-skin-muted/60 uppercase tracking-wide">{item.label}</dt>
+                <dd class="font-mono text-sm text-skin-base">{item.value}</dd>
+              </div>
+            {/each}
+          </dl>
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <div class="font-mono text-skin-muted">Error: Could not load setup.</div>
+  {/if}
+</section>


### PR DESCRIPTION
## What
Two cheap conventions with real discovery networks (nownownow.com, uses.tech) that also signal the site is actively maintained.

- **/now**: a dated snapshot of current focus, sourced from `content/now.yaml` so it updates without code changes. Seeded from verifiable current work (AWS agentic AI / ProveIT, this site's AI + reliability work, boo / mqtt-recorder / CampFit, Kiro workflows). Easy to keep fresh.
- **/uses**: hardware/software/tools, rendered from the **same `setup` section that powers /interests**, so the two never drift.

Both prerender, get canonical URLs, are added to `sitemap.xml`, and are linked from the footer; `/now` and `/uses` cross-link.

## Verification
- No em dashes; `svelte-check` 0/0; `eslint` clean
- Both prerender with correct canonical (no `sveltekit-prerender` leak) and titles
- `/now` reflects `now.yaml` (content + formatted "Last updated July 3, 2026")
- `/uses` reflects `interests.yaml` setup (single source of truth)
- Both in `sitemap.xml`; footer `[ now ] [ uses ]` links render

Note: the `content/now.yaml` copy is seeded and easy to edit; tweak the voice/emphasis anytime.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp