### PR TITLE
Add an MCP server: expose Brian as tools any agent can call

### DIFF
--- a/docs/architecture/ai-features.md
+++ b/docs/architecture/ai-features.md
@@ -65,9 +65,34 @@ The AI can call these tools during analysis:
 | `get_project` | `slug: string` | Get full project details |
 | `search_experience` | `keywords: string[]` | Search work experience by role/company |
 | `get_skills_by_category` | `category: string` | Get all skills in a category |
-| `get_resume_summary` | — | Get resume overview |
+| `get_resume_summary` | (none) | Get resume overview |
 
-**Tool execution:** Firebase function (`functions/src/index.ts`) executes tool calls and returns results to Gemini in a loop (max 10 iterations for Fit Finder, 5 for Chat).
+**Tool execution:** the Cloud Run handlers (`functions/src/handlers.ts`) execute tool calls and return results to Gemini in a loop (max 10 iterations for Fit Finder, 5 for Chat).
+
+## MCP Server
+
+**Implementation:** `site/functions/src/mcp.ts`, served at `POST /mcp` (`https://api.briananderson.xyz/mcp`).
+
+An MCP (Model Context Protocol) server over Streamable HTTP lets any MCP-capable
+agent query the site directly. It runs on the same Cloud Run service as the REST
+API and is stateless (`sessionIdGenerator: undefined`, `enableJsonResponse: true`),
+so a fresh server + transport is created per request, which suits Cloud Run's
+ephemeral, multi-instance model. It reuses the existing logic rather than
+duplicating it: `search_projects`/`search_skills` use the same `ContentTools` +
+content index as the chatbot, and `ask_brian`/`analyze_fit` invoke the real
+`handleChat`/`handleFitFinder` handlers through an in-process response adapter,
+so guardrails and grounding are identical.
+
+| MCP Tool | Parameters | Wraps |
+|------|-----------|-------|
+| `get_resume` | `variant?: leader\|ops\|builder` | Fetches the deployed `resume.json` variant |
+| `search_projects` | `query: string` | `ContentTools.searchProjects` |
+| `search_skills` | `query: string` | `ContentTools.searchSkills` |
+| `ask_brian` | `question: string` | `handleChat` |
+| `analyze_fit` | `job_description: string`, `variant?` | `handleFitFinder` |
+
+Advertised to agents in `/llms.txt`. Covered by `site/functions/src/mcp.test.ts`
+(hermetic, via the SDK's in-memory transport).
 
 ## Local Testing
 

--- a/site/functions/package.json
+++ b/site/functions/package.json
@@ -13,8 +13,10 @@
   "main": "lib/server.js",
   "dependencies": {
     "@google/genai": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "express": "^4.21.0",
-    "express-rate-limit": "^8.5.2"
+    "express-rate-limit": "^8.5.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/site/functions/pnpm-lock.yaml
+++ b/site/functions/pnpm-lock.yaml
@@ -16,13 +16,19 @@ importers:
     dependencies:
       '@google/genai':
         specifier: ^1.0.0
-        version: 1.40.0
+        version: 1.40.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       express:
         specifier: ^4.21.0
         version: 4.22.1
       express-rate-limit:
         specifier: ^8.5.2
         version: 8.5.2(express@4.22.1)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/express':
         specifier: ^5.0.0
@@ -45,9 +51,25 @@ packages:
       '@modelcontextprotocol/sdk':
         optional: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -87,9 +109,24 @@ packages:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -123,6 +160,10 @@ packages:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
@@ -152,16 +193,32 @@ packages:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
 
   cookie@0.7.2:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -238,6 +295,14 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   express-rate-limit@8.5.2:
     resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
     engines: {node: '>= 16'}
@@ -248,8 +313,18 @@ packages:
     resolution: {integrity: sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==}
     engines: {node: '>= 0.10.0'}
 
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
@@ -258,6 +333,10 @@ packages:
   finalhandler@1.3.2:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   foreground-child@3.3.1:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
@@ -274,6 +353,10 @@ packages:
   fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -323,6 +406,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -333,6 +420,10 @@ packages:
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   inherits@2.0.4:
@@ -350,14 +441,26 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -379,8 +482,16 @@ packages:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -390,9 +501,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
@@ -417,6 +536,10 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -426,6 +549,10 @@ packages:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -433,6 +560,9 @@ packages:
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
@@ -452,6 +582,13 @@ packages:
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   protobufjs@8.6.5:
     resolution: {integrity: sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==}
     engines: {node: '>=12.0.0'}
@@ -464,6 +601,10 @@ packages:
     resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -472,9 +613,21 @@ packages:
     resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
     engines: {node: '>= 0.8'}
 
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -486,9 +639,17 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serve-static@1.16.3:
     resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
     engines: {node: '>= 0.8.0'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -505,6 +666,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -515,6 +680,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   signal-exit@4.1.0:
@@ -548,6 +717,10 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -586,6 +759,9 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -598,17 +774,31 @@ packages:
       utf-8-validate:
         optional: true
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
-  '@google/genai@1.40.0':
+  '@google/genai@1.40.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.5.0
       protobufjs: 8.6.5
       ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -618,6 +808,28 @@ snapshots:
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -668,7 +880,23 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   agent-base@7.1.4: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -705,6 +933,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
@@ -733,11 +975,22 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  content-disposition@1.1.0: {}
+
   content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   cookie-signature@1.0.7: {}
 
+  cookie-signature@1.2.2: {}
+
   cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -791,9 +1044,20 @@ snapshots:
 
   etag@1.8.1: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   express-rate-limit@8.5.2(express@4.22.1):
     dependencies:
       express: 4.22.1
+      ip-address: 10.2.0
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
       ip-address: 10.2.0
 
   express@4.22.1:
@@ -832,7 +1096,44 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.14.1
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   extend@3.0.2: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.3: {}
 
   fetch-blob@3.2.0:
     dependencies:
@@ -851,6 +1152,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   foreground-child@3.3.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -863,6 +1175,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
+
+  fresh@2.0.0: {}
 
   function-bind@1.1.2: {}
 
@@ -939,6 +1253,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono@4.12.27: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -958,6 +1274,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   inherits@2.0.4: {}
 
   ip-address@10.2.0: {}
@@ -965,6 +1285,8 @@ snapshots:
   ipaddr.js@1.9.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
+
+  is-promise@4.0.0: {}
 
   isexe@2.0.0: {}
 
@@ -974,9 +1296,15 @@ snapshots:
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
 
+  jose@6.2.3: {}
+
   json-bigint@1.0.0:
     dependencies:
       bignumber.js: 9.3.1
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   jwa@2.0.1:
     dependencies:
@@ -997,15 +1325,25 @@ snapshots:
 
   media-typer@0.3.0: {}
 
+  media-typer@1.1.0: {}
+
   merge-descriptors@1.0.3: {}
+
+  merge-descriptors@2.0.0: {}
 
   methods@1.1.2: {}
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@1.6.0: {}
 
@@ -1021,6 +1359,8 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  negotiator@1.0.0: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -1029,11 +1369,17 @@ snapshots:
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
 
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   package-json-from-dist@1.0.1: {}
 
@@ -1048,6 +1394,10 @@ snapshots:
 
   path-to-regexp@0.1.13: {}
 
+  path-to-regexp@8.4.2: {}
+
+  pkce-challenge@5.0.1: {}
+
   protobufjs@8.6.5:
     dependencies:
       long: 5.3.2
@@ -1061,6 +1411,11 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   range-parser@1.2.1: {}
 
   raw-body@2.5.3:
@@ -1070,9 +1425,28 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.3
+      unpipe: 1.0.0
+
+  require-from-string@2.0.2: {}
+
   rimraf@5.0.10:
     dependencies:
       glob: 10.5.0
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
 
   safe-buffer@5.2.1: {}
 
@@ -1096,12 +1470,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serve-static@1.16.3:
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
     transitivePeerDependencies:
       - supports-color
 
@@ -1114,6 +1513,11 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -1138,6 +1542,14 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
       side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
@@ -1172,6 +1584,12 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
@@ -1200,4 +1618,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.2
 
+  wrappy@1.0.2: {}
+
   ws@8.21.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/site/functions/src/handlers.ts
+++ b/site/functions/src/handlers.ts
@@ -448,7 +448,7 @@ function stabilizeFitAnalysis(
 /**
  * Fetch content index using versioned approach to avoid stale cache
  */
-async function fetchContentIndex(): Promise<ContentIndex | null> {
+export async function fetchContentIndex(): Promise<ContentIndex | null> {
 	if (contentIndexCache && contentIndexVersion) {
 		return contentIndexCache;
 	}

--- a/site/functions/src/mcp.test.ts
+++ b/site/functions/src/mcp.test.ts
@@ -1,0 +1,66 @@
+/**
+ * node:test coverage for the MCP server wiring in site/functions/src/mcp.ts.
+ * Uses the SDK's in-memory transport + client so the test is hermetic: it
+ * exercises the real MCP handshake and tool registration without a network
+ * call, an HTTP server, or Gemini. Run via `pnpm test`.
+ */
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from './mcp.js';
+
+const EXPECTED_TOOLS = ['get_resume', 'search_projects', 'search_skills', 'ask_brian', 'analyze_fit'];
+
+async function connectedClient(): Promise<{ client: Client; close: () => Promise<void> }> {
+	const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+	const server = createMcpServer();
+	const client = new Client({ name: 'test', version: '1.0.0' });
+	await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+	return {
+		client,
+		close: async () => {
+			await client.close();
+			await server.close();
+		},
+	};
+}
+
+describe('MCP server', () => {
+	test('completes the initialize handshake and advertises tool capability', async () => {
+		const { client, close } = await connectedClient();
+		const caps = client.getServerCapabilities();
+		assert.ok(caps?.tools, 'server should advertise tools capability');
+		await close();
+	});
+
+	test('registers exactly the expected tools', async () => {
+		const { client, close } = await connectedClient();
+		const { tools } = await client.listTools();
+		const names = tools.map((t) => t.name).sort();
+		assert.deepEqual(names, [...EXPECTED_TOOLS].sort());
+		await close();
+	});
+
+	test('every tool exposes a description and input schema', async () => {
+		const { client, close } = await connectedClient();
+		const { tools } = await client.listTools();
+		for (const tool of tools) {
+			assert.ok(tool.description && tool.description.length > 0, `${tool.name} needs a description`);
+			assert.equal(tool.inputSchema?.type, 'object', `${tool.name} needs an object input schema`);
+		}
+		await close();
+	});
+
+	test('search tools require their query argument', async () => {
+		const { client, close } = await connectedClient();
+		const { tools } = await client.listTools();
+		for (const name of ['search_projects', 'search_skills']) {
+			const schema = tools.find((t) => t.name === name)?.inputSchema as
+				| { required?: string[] }
+				| undefined;
+			assert.ok(schema?.required?.includes('query'), `${name} should require "query"`);
+		}
+		await close();
+	});
+});

--- a/site/functions/src/mcp.ts
+++ b/site/functions/src/mcp.ts
@@ -1,0 +1,165 @@
+/**
+ * MCP (Model Context Protocol) server for briananderson.xyz.
+ *
+ * Exposes Brian's resume, projects, skills, chatbot, and fit-finder as MCP
+ * tools so any MCP-capable agent can query them directly. Served over
+ * Streamable HTTP at POST /mcp on the same Cloud Run service as the REST API.
+ *
+ * The tools reuse the existing logic rather than reimplementing it:
+ * - get_resume fetches the deployed JSONResume endpoints
+ * - search_projects / search_skills use the same ContentTools + content index
+ *   the chatbot uses
+ * - ask_brian / analyze_fit invoke the real chat / fit-finder handlers through
+ *   a lightweight response adapter, so guardrails and grounding are identical
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Request, Response } from 'express';
+import { z } from 'zod';
+import { fetchContentIndex, handleChat, handleFitFinder } from './handlers.js';
+import { ContentTools } from './tools.js';
+
+const SITE_URL = process.env.SITE_URL || 'https://briananderson.xyz';
+
+const SERVER_INFO = { name: 'briananderson-xyz', version: '1.0.0' } as const;
+
+/**
+ * Invoke an Express-style handler (handleChat / handleFitFinder) in-process and
+ * capture its JSON response, so MCP tools reuse the exact same request logic,
+ * guardrails, and grounding without an HTTP round-trip or duplicated code.
+ */
+function invokeHandler(
+	handler: (req: Request, res: Response) => unknown,
+	body: unknown
+): Promise<{ status: number; data: Record<string, unknown> }> {
+	return new Promise((resolve, reject) => {
+		let statusCode = 200;
+		const req = { method: 'POST', headers: {}, body } as unknown as Request;
+		const res = {
+			set: () => res,
+			setHeader: () => res,
+			status: (code: number) => {
+				statusCode = code;
+				return res;
+			},
+			json: (payload: Record<string, unknown>) => {
+				resolve({ status: statusCode, data: payload });
+				return res;
+			},
+			send: (payload: unknown) => {
+				resolve({ status: statusCode, data: { body: payload } });
+				return res;
+			},
+			end: () => {
+				resolve({ status: statusCode, data: {} });
+				return res;
+			},
+		} as unknown as Response;
+		Promise.resolve(handler(req, res)).catch(reject);
+	});
+}
+
+function textResult(value: unknown, isError = false) {
+	const text = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+	return { content: [{ type: 'text' as const, text }], isError };
+}
+
+/**
+ * Build a fresh MCP server with all tools registered. In stateless Streamable
+ * HTTP mode a new instance is created per request.
+ */
+export function createMcpServer(): McpServer {
+	const server = new McpServer(SERVER_INFO);
+
+	server.registerTool(
+		'get_resume',
+		{
+			title: "Get Brian's resume",
+			description:
+				"Return Brian Anderson's resume as JSONResume. Optionally pass a variant to emphasize a persona: 'leader' (default, enterprise architecture and strategy), 'ops' (platform/DevOps), or 'builder' (hands-on building).",
+			inputSchema: { variant: z.enum(['leader', 'ops', 'builder']).optional() },
+		},
+		async ({ variant }) => {
+			const path =
+				variant === 'ops' ? '/ops/resume.json' : variant === 'builder' ? '/builder/resume.json' : '/resume.json';
+			const response = await fetch(`${SITE_URL}${path}`);
+			if (!response.ok) {
+				return textResult(`Failed to fetch resume (${response.status}).`, true);
+			}
+			return textResult(await response.text());
+		}
+	);
+
+	server.registerTool(
+		'search_projects',
+		{
+			title: "Search Brian's projects",
+			description:
+				"Search Brian's projects by keyword (e.g. 'agent', 'kubernetes', 'observability'). Returns matching projects with summaries and links.",
+			inputSchema: { query: z.string().min(1).describe('Keywords to search projects for') },
+		},
+		async ({ query }) => {
+			const index = await fetchContentIndex();
+			if (!index) return textResult('Content index is unavailable.', true);
+			const keywords = query.trim().split(/\s+/).filter(Boolean);
+			return textResult(new ContentTools(index).searchProjects(keywords));
+		}
+	);
+
+	server.registerTool(
+		'search_skills',
+		{
+			title: "Search Brian's skills",
+			description:
+				"Search Brian's skills by keyword (e.g. 'rust', 'terraform', 'ai'). Returns matching skills with the projects and posts that evidence them.",
+			inputSchema: { query: z.string().min(1).describe('Keywords to search skills for') },
+		},
+		async ({ query }) => {
+			const index = await fetchContentIndex();
+			if (!index) return textResult('Content index is unavailable.', true);
+			const keywords = query.trim().split(/\s+/).filter(Boolean);
+			return textResult(new ContentTools(index).searchSkills(keywords));
+		}
+	);
+
+	server.registerTool(
+		'ask_brian',
+		{
+			title: 'Ask Brian a question',
+			description:
+				"Ask a free-form question about Brian's background, experience, or work. Answered by the same AI assistant that powers the site chatbot, grounded in Brian's real content.",
+			inputSchema: { question: z.string().min(1).describe('The question to ask') },
+		},
+		async ({ question }) => {
+			const { status, data } = await invokeHandler(handleChat, { message: question, history: [] });
+			if (status >= 400) {
+				return textResult(String(data.error || 'Chat request failed.'), true);
+			}
+			return textResult(String(data.response ?? ''));
+		}
+	);
+
+	server.registerTool(
+		'analyze_fit',
+		{
+			title: 'Analyze fit for a role',
+			description:
+				"Score how well Brian fits a role. Pass the job description; returns a structured analysis (fit score, matching skills and experience, gaps, and a recommended resume variant).",
+			inputSchema: {
+				job_description: z.string().min(1).describe('The full job description to analyze'),
+				variant: z.enum(['leader', 'ops', 'builder']).optional(),
+			},
+		},
+		async ({ job_description, variant }) => {
+			const { status, data } = await invokeHandler(handleFitFinder, {
+				jobDescription: job_description,
+				variant,
+			});
+			if (status >= 400) {
+				return textResult(String(data.error || 'Fit analysis failed.'), true);
+			}
+			return textResult(data.analysis ?? data);
+		}
+	);
+
+	return server;
+}

--- a/site/functions/src/server.ts
+++ b/site/functions/src/server.ts
@@ -8,9 +8,11 @@
  */
 import express from 'express';
 import { rateLimit, ipKeyGenerator } from 'express-rate-limit';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { handleChat } from './handlers.js';
 import { handleFitFinder } from './handlers.js';
 import { corsHeadersFor } from './security.js';
+import { createMcpServer } from './mcp.js';
 
 const asyncHandler = (fn: express.RequestHandler) => (req: express.Request, res: express.Response, next: express.NextFunction) => {
 	Promise.resolve(fn(req, res, next)).catch(next);
@@ -81,6 +83,28 @@ app.post('/chat', apiLimiter, asyncHandler((req, res) => handleChat(req, res)));
 app.options('/chat', asyncHandler((req, res) => handleChat(req, res)));
 app.post('/fit-finder', apiLimiter, asyncHandler((req, res) => handleFitFinder(req, res)));
 app.options('/fit-finder', asyncHandler((req, res) => handleFitFinder(req, res)));
+
+// MCP (Model Context Protocol) endpoint over Streamable HTTP. Stateless: a
+// fresh server + transport per request (enableJsonResponse returns a single
+// JSON-RPC response rather than an SSE stream, which suits these
+// request/response tools). Rate-limited like the other endpoints.
+app.post('/mcp', apiLimiter, asyncHandler(async (req, res) => {
+	const server = createMcpServer();
+	const transport = new StreamableHTTPServerTransport({
+		sessionIdGenerator: undefined,
+		enableJsonResponse: true,
+	});
+	res.on('close', () => {
+		transport.close();
+		server.close();
+	});
+	await server.connect(transport);
+	await transport.handleRequest(req, res, req.body);
+}));
+// Streamable HTTP session GET/DELETE are unused in stateless mode.
+app.get('/mcp', (_req, res) => {
+	res.status(405).json({ error: 'Method not allowed' });
+});
 
 app.use((err: Error & { status?: number; statusCode?: number }, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
 	console.error('Unhandled error:', err);

--- a/site/src/routes/llms.txt/+server.ts
+++ b/site/src/routes/llms.txt/+server.ts
@@ -102,6 +102,14 @@ Response:
 }
 \`\`\`
 
+### MCP Server (POST https://api.briananderson.xyz/mcp)
+An MCP (Model Context Protocol) server over Streamable HTTP, so any MCP-capable agent can query Brian directly. Add \`https://api.briananderson.xyz/mcp\` as a Streamable-HTTP MCP server. Stateless JSON-RPC: send \`initialize\`, then \`tools/list\` or \`tools/call\`. Tools:
+- \`get_resume(variant?: "leader" | "ops" | "builder")\` - Brian's resume as JSONResume for the chosen persona.
+- \`search_projects(query: string)\` - projects matching keywords, with summaries and links.
+- \`search_skills(query: string)\` - skills matching keywords, with the projects/posts that evidence them.
+- \`ask_brian(question: string)\` - free-form Q&A grounded in Brian's content (same engine as the site chatbot).
+- \`analyze_fit(job_description: string, variant?: "leader" | "ops" | "builder")\` - structured fit analysis of a role against Brian's background.
+
 ## About Brian
 
 ${resume.summary}


### PR DESCRIPTION
## What
The site's best AI affordances (chat, fit-finder, content index) were only reachable as bespoke HTTP calls. This adds an **MCP (Model Context Protocol) server** so any MCP-capable agent can "add Brian" and query him directly. It's both a working interface and a portfolio piece for the agentic-systems positioning: nobody else's resume ships an MCP server.

## How
Served at **`POST /mcp`** on the existing Cloud Run service over **Streamable HTTP**, stateless (`sessionIdGenerator: undefined`, `enableJsonResponse: true`) so a fresh server + transport is created per request, which fits Cloud Run's ephemeral, multi-instance model. Rate-limited like the other endpoints. Uses the official `@modelcontextprotocol/sdk`.

### Tools (all reuse existing logic, no duplication)
| Tool | Wraps |
|---|---|
| `get_resume(variant?)` | the deployed `resume.json` variant |
| `search_projects(query)` | `ContentTools.searchProjects` (same index as the chatbot) |
| `search_skills(query)` | `ContentTools.searchSkills` |
| `ask_brian(question)` | the real `handleChat` (in-process adapter, identical guardrails/grounding) |
| `analyze_fit(job_description, variant?)` | the real `handleFitFinder` |

## Also
- **Advertised in `/llms.txt`** (Agent API section) with the tool list.
- Documented in `docs/architecture/ai-features.md`.
- **Hermetic test** (`mcp.test.ts`) via the SDK's in-memory transport: verifies the initialize handshake, the exact tool set, and each tool's schema. No network or Gemini, CI-safe.

## Verification
- Functions build + **all 38 tests pass** (4 new MCP tests)
- Booted the server and exercised the **real protocol via curl**: `initialize`, `tools/list`, and every tool. `get_resume` / `search_projects` / `search_skills` / `ask_brian` return correct grounded data; `analyze_fit` returns a structured analysis (transient fit-finder nondeterminism surfaces correctly as `isError`). Unknown-tool and missing-arg calls return proper JSON-RPC errors.
- `llms.txt` renders the MCP section; `svelte-check` 0/0; `eslint` clean; no em dashes.

## Rollout
Merging deploys the endpoint to **dev** (`api-dev.briananderson.xyz/mcp`), where I'll verify it live. The **prod** URL advertised in llms.txt goes live on the **next manual prod deploy** (`workflow_dispatch`), matching how the existing `/chat` and `/fit-finder` Agent API URLs already work.

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp