### PR TITLE
Harden the AI API: app kill switch, Cloud Run caps, graceful frontend

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -158,6 +158,8 @@ jobs:
             --set-secrets "GEMINI_API_KEY=gemini-api-key:latest" \
             --service-account "cloud-run-runtime@${PROJECT_ID}.iam.gserviceaccount.com" \
             --max-instances 5 \
+            --concurrency 20 \
+            --timeout 120 \
             --memory 512Mi
       - name: Deploy fitfinder-dev
         env:
@@ -177,6 +179,8 @@ jobs:
             --set-secrets "GEMINI_API_KEY=gemini-api-key:latest" \
             --service-account "cloud-run-runtime@${PROJECT_ID}.iam.gserviceaccount.com" \
             --max-instances 5 \
+            --concurrency 20 \
+            --timeout 120 \
             --memory 512Mi
       - name: Smoke test dev Cloud Run services
         id: smoke
@@ -279,6 +283,8 @@ jobs:
             --set-secrets "GEMINI_API_KEY=gemini-api-key:latest" \
             --service-account "cloud-run-runtime@${PROJECT_ID}.iam.gserviceaccount.com" \
             --max-instances 10 \
+            --concurrency 20 \
+            --timeout 120 \
             --memory 512Mi
       - name: Deploy fitfinder (prod)
         env:
@@ -298,6 +304,8 @@ jobs:
             --set-secrets "GEMINI_API_KEY=gemini-api-key:latest" \
             --service-account "cloud-run-runtime@${PROJECT_ID}.iam.gserviceaccount.com" \
             --max-instances 10 \
+            --concurrency 20 \
+            --timeout 120 \
             --memory 512Mi
       - name: Smoke test prod Cloud Run services
         id: smoke

--- a/site/functions/src/handlers.ts
+++ b/site/functions/src/handlers.ts
@@ -26,6 +26,7 @@ import {
 	MAX_MESSAGE_BYTES,
 	MAX_JOBDESC_BYTES,
 	isValidVariant,
+	aiEnabled,
 	type Variant
 } from './security.js';
 
@@ -603,6 +604,13 @@ export async function handleChat(req: Request, res: Response): Promise<void> {
 		return;
 	}
 
+	// Kill switch: skip all work (and Gemini spend) when AI is disabled.
+	if (!aiEnabled()) {
+		res.set(corsHeadersFor(req));
+		res.status(503).json({ error: 'AI features are temporarily unavailable.', code: 'ai_disabled' });
+		return;
+	}
+
 	try {
 		const { message, history = [], variant: rawVariant }: ChatRequest = req.body;
 
@@ -766,6 +774,13 @@ export async function handleFitFinder(req: Request, res: Response): Promise<void
 
 	if (req.method !== 'POST') {
 		res.status(405).json({ error: 'Method not allowed' });
+		return;
+	}
+
+	// Kill switch: skip all work (and Gemini spend) when AI is disabled.
+	if (!aiEnabled()) {
+		res.set(corsHeadersFor(req));
+		res.status(503).json({ error: 'AI features are temporarily unavailable.', code: 'ai_disabled' });
 		return;
 	}
 

--- a/site/functions/src/security.test.ts
+++ b/site/functions/src/security.test.ts
@@ -15,7 +15,8 @@ import {
 	MAX_HISTORY,
 	MAX_HISTORY_CONTENT_BYTES,
 	ALLOWED_VARIANTS,
-	isValidVariant
+	isValidVariant,
+	aiEnabled
 } from './security.js';
 
 describe('isAllowedCtaLink — AC-11 bypass vectors', () => {
@@ -186,5 +187,33 @@ describe('isValidVariant — AC-16', () => {
 
 	test('is case-sensitive (does not silently normalize)', () => {
 		assert.equal(isValidVariant('Leader'), false);
+	});
+});
+
+describe('aiEnabled — kill switch', () => {
+	const original = process.env.AI_ENABLED;
+	const restore = () => {
+		if (original === undefined) delete process.env.AI_ENABLED;
+		else process.env.AI_ENABLED = original;
+	};
+
+	test('defaults to enabled when AI_ENABLED is unset', () => {
+		delete process.env.AI_ENABLED;
+		assert.equal(aiEnabled(), true);
+		restore();
+	});
+
+	test('disabled only when explicitly "false"', () => {
+		process.env.AI_ENABLED = 'false';
+		assert.equal(aiEnabled(), false);
+		restore();
+	});
+
+	test('any other value stays enabled (no accidental dark-ship)', () => {
+		for (const v of ['true', 'FALSE', '0', 'off', '']) {
+			process.env.AI_ENABLED = v;
+			assert.equal(aiEnabled(), true, `value "${v}" should be enabled`);
+		}
+		restore();
 	});
 });

--- a/site/functions/src/security.ts
+++ b/site/functions/src/security.ts
@@ -172,3 +172,14 @@ export type Variant = (typeof ALLOWED_VARIANTS)[number];
 export function isValidVariant(variant: unknown): variant is Variant {
 	return typeof variant === 'string' && (ALLOWED_VARIANTS as readonly string[]).includes(variant);
 }
+
+/**
+ * Kill switch. When AI_ENABLED is explicitly "false" (set manually via
+ * `gcloud run services update ... --update-env-vars AI_ENABLED=false`, or by
+ * the budget-breach automation), the AI handlers short-circuit with a
+ * structured 503 {code:"ai_disabled"} and make no Gemini call. Defaults to
+ * enabled so a missing/typo'd value never dark-ships the API.
+ */
+export function aiEnabled(): boolean {
+	return process.env.AI_ENABLED !== 'false';
+}

--- a/site/src/lib/components/Chatbot.svelte
+++ b/site/src/lib/components/Chatbot.svelte
@@ -6,6 +6,7 @@
 	import ChatInput from './ChatInput.svelte';
 	import Modal from './Modal.svelte';
 	import { getApiBase } from '$lib/utils/apiBase';
+	import { describeApiError } from '$lib/utils/apiError';
 	import { fly } from 'svelte/transition';
 
 	const API_BASE = getApiBase();
@@ -112,7 +113,18 @@
 			});
 
 			if (!response.ok) {
-				throw new Error('Failed to get response');
+				const body = await response.json().catch(() => null);
+				const info = describeApiError(response.status, body);
+				messages = [
+					...messages,
+					{
+						id: (Date.now() + 1).toString(),
+						role: 'system',
+						content: info.message,
+						timestamp: Date.now()
+					}
+				];
+				return;
 			}
 
 			const data = await response.json();

--- a/site/src/lib/components/FitFinder.svelte
+++ b/site/src/lib/components/FitFinder.svelte
@@ -4,6 +4,7 @@
 	import { trackEvent } from '$lib/utils/analytics';
 	import Modal from './Modal.svelte';
 	import { getApiBase } from '$lib/utils/apiBase';
+	import { describeApiError } from '$lib/utils/apiError';
 
 	const API_BASE = getApiBase();
 
@@ -48,10 +49,11 @@
 				})
 			});
 
-			const data = await response.json();
+			const data = await response.json().catch(() => null);
 
 			if (!response.ok) {
-				throw new Error(data.details || data.error || 'Failed to analyze job description');
+				error = describeApiError(response.status, data).message;
+				return;
 			}
 
 			analysis = data.analysis;

--- a/site/src/lib/utils/apiError.ts
+++ b/site/src/lib/utils/apiError.ts
@@ -1,0 +1,51 @@
+/**
+ * Maps an AI API error response to a friendly, user-facing message.
+ *
+ * The edge worker and the Cloud Run handlers return structured error bodies
+ * with a `code` for expected states, so the UI can degrade gracefully instead
+ * of showing a generic failure:
+ *   - 429 / code "rate_limited"  -> the caller hit the per-IP rate limit
+ *   - 503 / code "ai_disabled"   -> AI features are turned off (kill switch /
+ *                                   budget cap)
+ */
+export interface ApiErrorBody {
+  code?: string;
+  error?: string;
+  details?: string;
+}
+
+export interface ApiErrorInfo {
+  message: string;
+  code?: string;
+}
+
+export function describeApiError(status: number, body: ApiErrorBody | null | undefined): ApiErrorInfo {
+  const code = body?.code;
+  const serverMessage = body?.details || body?.error;
+
+  if (status === 429 || code === 'rate_limited') {
+    return {
+      code: 'rate_limited',
+      message: "You're sending requests a bit too quickly. Please wait a moment and try again.",
+    };
+  }
+
+  if (code === 'ai_disabled') {
+    return {
+      code: 'ai_disabled',
+      message: 'AI features are temporarily unavailable. Please check back soon.',
+    };
+  }
+
+  if (status === 503) {
+    return {
+      code,
+      message: serverMessage || 'The AI service is temporarily unavailable. Please try again later.',
+    };
+  }
+
+  return {
+    code,
+    message: serverMessage || 'Something went wrong. Please try again.',
+  };
+}


### PR DESCRIPTION
## What
Defense-in-depth for API abuse/cost, complementing the **edge** rate limiting + kill switch (DNS repo PR #7). This layer needs no Cloudflare change, so it also provides an **immediately usable kill switch today** (via `gcloud run`) while the CF token permission for the edge KV is sorted.

## App kill switch (`site/functions`)
- `aiEnabled()` in `security.ts`: `AI_ENABLED="false"` disables the AI handlers, which return `503 {"code":"ai_disabled"}` **before any Gemini call**. Defaults to enabled (a missing/typo'd value never dark-ships).
- Toggle live: `gcloud run services update chat --update-env-vars AI_ENABLED=false` (+ `fitfinder`). The budget-breach automation will flip it too.
- The MCP `ask_brian` / `analyze_fit` tools inherit it (same handlers, in-process).

## Cloud Run caps (`build-and-deploy.yml`)
- `--concurrency 20` + `--timeout 120` on all four deploys. Bounds how far a burst fans out into concurrent Gemini calls and kills runaway requests, on top of `--max-instances`.

## Graceful frontend (`site/src`)
- New `describeApiError()` maps **429** (`rate_limited`) and **503** (`ai_disabled`) to friendly messages. `Chatbot` and `FitFinder` use it, so a rate-limited or disabled API shows "slow down" / "temporarily unavailable" instead of a generic error.

## Verification
- Functions build + **41 tests pass** (3 new `aiEnabled` tests); `svelte-check` 0/0; `eslint` clean; YAML valid.
- Booted the server with `AI_ENABLED=false`: `/chat` → `503 {"code":"ai_disabled"}` with **no Gemini call**; `/mcp` `ask_brian` → `isError` with the disabled message.

## Context
- Edge layer (robust per-IP rate limiting + KV kill switch): DNS PR #7, merged, apply **blocked** on adding `Workers KV Storage:Edit` to the CF API token.
- Budget cap + hard-stop automation: next PR (app infra).

https://claude.ai/code/session_01Lt6WScB8HEavtHHRozs7Mp