### PR TITLE
Fix dev workflow validation environment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -29,6 +29,8 @@ jobs:
         env:
           PUBLIC_SITE_URL: https://dev.briananderson.xyz
           PUBLIC_ENV: dev
+          PUBLIC_POSTHOG_KEY: phc_ci_validation_only
+          PUBLIC_POSTHOG_HOST: https://posthog.invalid
         run: pnpm run validate
 
   build-functions:

--- a/site/scripts/validate-delivery-workflows.mjs
+++ b/site/scripts/validate-delivery-workflows.mjs
@@ -36,6 +36,22 @@ expect(!automaticOn?.pull_request && !automaticOn?.schedule, "automatic workflow
 expect(Boolean(automatic.workflow.jobs?.validate), "automatic workflow must retain validation");
 expect(Boolean(automatic.workflow.jobs?.["build-functions"]), "automatic workflow must test the container without credentials");
 
+const validationEnv = automatic.workflow.jobs?.validate?.steps?.find(
+  (step) => step?.name === "Validate site"
+)?.env;
+expect(
+  validationEnv?.PUBLIC_POSTHOG_KEY === "phc_ci_validation_only",
+  "automatic validation must provide the deterministic non-secret PostHog key placeholder"
+);
+expect(
+  validationEnv?.PUBLIC_POSTHOG_HOST === "https://posthog.invalid",
+  "automatic validation must provide the deterministic non-secret PostHog host placeholder"
+);
+expect(
+  !JSON.stringify(validationEnv ?? {}).includes("secrets."),
+  "automatic validation must remain credential-free"
+);
+
 for (const jobName of ["publish-functions", "deploy-functions-dev", "deploy-site-dev"]) {
   const job = automatic.workflow.jobs?.[jobName];
   expect(Boolean(job), `automatic workflow is missing ${jobName}`);


### PR DESCRIPTION
## Summary

Fixes the post-merge `Build and Deploy Dev` validation failure from run [29063905585](https://github.com/briananderson-xyz/briananderson-xyz/actions/runs/29063905585).

SvelteKit generates `$env/static/public` exports only for declared variables. PR validation declared the public PostHog variables, but the main-push validation job did not, causing five type errors before the container build.

This change:

- supplies deterministic, non-secret validation-only values for `PUBLIC_POSTHOG_KEY` and `PUBLIC_POSTHOG_HOST`
- uses the reserved `.invalid` domain so validation cannot target real telemetry
- adds delivery-policy assertions for the exact placeholders and credential-free validation job
- leaves the gated dev deployment build on environment secrets
- does not change production, Terraform, IAM, WIF, or deployment enablement

## Acceptance Evidence

| AC id | Status | Command/Test Evidence | Source Evidence / Permalinks | Gaps |
| --- | --- | --- | --- | --- |
| DV-01 | PASS | Full `pnpm run validate` with the exact four main-workflow variables exits 0; 0 Svelte errors/warnings; PostHog 15/15 | [validation env](https://github.com/briananderson-xyz/briananderson-xyz/blob/074230d/.github/workflows/build-and-deploy.yml), [policy assertions](https://github.com/briananderson-xyz/briananderson-xyz/blob/074230d/site/scripts/validate-delivery-workflows.mjs) | Provider rerun pending |
| DV-02 | PASS | Workflow/delivery/infra policy and YAML parsing pass | [delivery policy](https://github.com/briananderson-xyz/briananderson-xyz/blob/074230d/site/scripts/validate-delivery-workflows.mjs) | Provider rerun pending |
| DV-03 | PASS | Parsed comparison proves automatic workflow unchanged outside validation env; prod and Terraform workflows byte-identical to merged main | [commit](https://github.com/briananderson-xyz/briananderson-xyz/commit/074230d) | Live dev remains intentionally unconfigured |
| DV-04 | PASS | Focused code, security, and verifier reviews pass; two-file diff only | [commit](https://github.com/briananderson-xyz/briananderson-xyz/commit/074230d) | Main-push observation pending merge |

## Deployment boundary

`DEV_DEPLOY_ENABLED` and the new publisher/dev credentials remain absent. After merge, validation and the credential-free container build should run; publisher and dev deployment jobs should skip. Production and Terraform workflows must remain undispatched.
