### PR TITLE
Restore PR-gated Terraform delivery

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,26 +1,23 @@
-name: Terraform Apply (manual)
+name: Terraform Apply (main)
 
 on:
-  workflow_dispatch:
-    inputs:
-      source_sha:
-        description: "Exact 40-character SHA currently at the tip of main"
-        required: true
-        type: string
-      confirmation:
-        description: "Type APPLY_TERRAFORM to create and apply a plan"
-        required: true
-        type: string
+  push:
+    branches: ["main"]
+    paths:
+      - "infra/terraform/**"
+      - ".github/workflows/terraform-pr.yml"
+      - ".github/workflows/terraform-apply.yml"
+      - "site/scripts/validate-workflow-policy.mjs"
+      - "site/scripts/validate-delivery-workflows.mjs"
 
 permissions: {}
 
 concurrency:
-  group: terraform-apply
+  group: terraform-backend-gcp-infra
   cancel-in-progress: false
 
 jobs:
   apply:
-    if: github.ref == 'refs/heads/main' && inputs.confirmation == 'APPLY_TERRAFORM'
     runs-on: ubuntu-latest
     environment: terraform-apply
     permissions:
@@ -29,21 +26,18 @@ jobs:
     env:
       TF_IN_AUTOMATION: "true"
       TF_INPUT: "false"
-      SOURCE_SHA: ${{ inputs.source_sha }}
+      SOURCE_SHA: ${{ github.sha }}
     steps:
-      - name: Validate confirmation and SHA shape
-        run: |
-          test "${{ inputs.confirmation }}" = "APPLY_TERRAFORM"
-          printf '%s' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'
-
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
-          ref: ${{ inputs.source_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
       - name: Verify exact current main revision
         run: |
+          set -euo pipefail
+          printf '%s' "$SOURCE_SHA" | grep -Eq '^[0-9a-f]{40}$'
           git fetch --no-tags origin refs/heads/main:refs/remotes/origin/main
           test "$(git rev-parse HEAD)" = "$SOURCE_SHA"
           test "$(git rev-parse refs/remotes/origin/main)" = "$SOURCE_SHA"
@@ -59,33 +53,44 @@ jobs:
         with:
           terraform_version: 1.15.8
 
-      - name: Terraform Init (GCS backend)
+      - name: Initialize exact remote backend
         run: >-
           terraform -chdir=infra/terraform init
           -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}"
           -backend-config="prefix=gcp/infra"
 
-      - name: Terraform Format and Validate
+      - name: Validate reviewed source
         run: |
           terraform -chdir=infra/terraform fmt -check -recursive
           terraform -chdir=infra/terraform validate -no-color
-          infra/terraform/check-policy.sh
+          infra/terraform/test-check-policy.sh
 
-      - name: Create saved plan for the checked-out SHA
+      - name: Create fresh locked plan for this main SHA
         run: |
+          set -euo pipefail
           terraform -chdir=infra/terraform plan \
-            -var="project_id=${{ secrets.GCP_PROJECT_ID }}" \
-            -var="region=${{ secrets.GCP_REGION }}" \
+            -input=false \
+            -var="project_id=${{ vars.GCP_PROJECT_ID }}" \
+            -var="region=${{ vars.GCP_REGION }}" \
             -var="github_org=${{ github.repository_owner }}" \
             -var="github_repo=${{ github.event.repository.name }}" \
-            -var="bucket_name=${{ secrets.SITE_BUCKET_NAME }}" \
-            -out=tfplan.out
-          printf '### Terraform apply\n\n- Source SHA: `%s`\n- Saved plan created in this job.\n- Binary plan is never uploaded.\n' \
-            "$SOURCE_SHA" >> "$GITHUB_STEP_SUMMARY"
+            -var="bucket_name=${{ vars.SITE_BUCKET_NAME }}" \
+            -var="terraform_state_bucket=${{ secrets.TF_STATE_BUCKET }}" \
+            -var="manage_deployment_service_iam=true" \
+            -out=tfplan.out >/dev/null
+          terraform -chdir=infra/terraform show -json tfplan.out > infra/terraform/tfplan.json
+          counts="$(jq -r '
+            [.resource_changes[]? | .change.actions] as $actions |
+            "add=" + ([$actions[] | select(index("create"))] | length | tostring) +
+            " change=" + ([$actions[] | select(index("update"))] | length | tostring) +
+            " destroy=" + ([$actions[] | select(index("delete"))] | length | tostring)
+          ' infra/terraform/tfplan.json)"
+          printf '### Terraform apply\n\n- Source SHA: `%s`\n- Backend prefix: `gcp/infra`\n- Fresh locked plan: `%s`\n- The same local saved plan is applied below.\n' \
+            "$SOURCE_SHA" "$counts" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Apply the same saved plan
-        run: terraform -chdir=infra/terraform apply -auto-approve tfplan.out
+      - name: Apply the same fresh saved plan
+        run: terraform -chdir=infra/terraform apply -no-color -auto-approve tfplan.out >/dev/null
 
-      - name: Delete saved plan
+      - name: Delete all plan material
         if: always()
-        run: rm -f infra/terraform/tfplan.out
+        run: rm -f infra/terraform/tfplan.out infra/terraform/tfplan.json

--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -1,12 +1,9 @@
-name: Terraform Validate (PR)
+name: Terraform PR Gate
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ["main"]
-    paths:
-      - "infra/terraform/**"
-      - ".github/workflows/terraform-*.yml"
 
 permissions: {}
 
@@ -14,14 +11,52 @@ concurrency:
   group: terraform-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  TF_IN_AUTOMATION: "true"
+  TF_INPUT: "false"
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      terraform: ${{ steps.diff.outputs.terraform }}
+      same_repository: ${{ steps.diff.outputs.same_repository }}
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect Terraform trust-boundary changes from immutable revisions
+        id: diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$HEAD_SHA"
+          git cat-file -e "${BASE_SHA}^{commit}"
+          changed="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          if grep -Eq '^(infra/terraform/|\.github/workflows/terraform-(pr|apply)\.yml$|site/scripts/(validate-workflow-policy|validate-delivery-workflows)\.mjs$)' <<<"$changed"; then
+            echo "terraform=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "terraform=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "$HEAD_REPOSITORY" = "$REPOSITORY" ]; then
+            echo "same_repository=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "same_repository=false" >> "$GITHUB_OUTPUT"
+          fi
+
   validate:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    env:
-      TF_IN_AUTOMATION: "true"
-      TF_INPUT: "false"
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
@@ -45,5 +80,128 @@ jobs:
       - name: Terraform Validate
         run: terraform -chdir=infra/terraform validate -no-color
 
-      - name: Trust-boundary policy
-        run: infra/terraform/check-policy.sh
+      - name: Trust-boundary policy and hostile-path tests
+        run: infra/terraform/test-check-policy.sh
+
+  plan:
+    needs: changes
+    if: needs.changes.outputs.terraform == 'true' && needs.changes.outputs.same_repository == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+
+      - name: Verify checked out revision
+        run: test "$(git rev-parse HEAD)" = "${{ github.event.pull_request.head.sha }}"
+
+      - name: Authenticate as read-only Terraform planner
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PLAN_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_PLAN_SA_EMAIL }}
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: 1.15.8
+
+      - name: Initialize exact remote backend
+        run: >-
+          terraform -chdir=infra/terraform init
+          -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}"
+          -backend-config="prefix=gcp/infra"
+
+      - name: Create read-only saved plan
+        run: |
+          set -euo pipefail
+          terraform -chdir=infra/terraform plan \
+            -lock=false \
+            -input=false \
+            -var="project_id=${{ vars.GCP_PROJECT_ID }}" \
+            -var="region=${{ vars.GCP_REGION }}" \
+            -var="github_org=${{ github.repository_owner }}" \
+            -var="github_repo=${{ github.event.repository.name }}" \
+            -var="bucket_name=${{ vars.SITE_BUCKET_NAME }}" \
+            -var="terraform_state_bucket=${{ secrets.TF_STATE_BUCKET }}" \
+            -var="manage_deployment_service_iam=true" \
+            -out=tfplan.out >/dev/null
+
+      - name: Produce sanitized plan evidence
+        env:
+          SOURCE_SHA: ${{ github.event.pull_request.head.sha }}
+          BACKEND_PREFIX: gcp/infra
+        run: |
+          set -euo pipefail
+          terraform -chdir=infra/terraform show -json tfplan.out > infra/terraform/tfplan.json
+          infra/terraform/sanitize-plan-evidence.sh \
+            infra/terraform/tfplan.json \
+            infra/terraform/plan-evidence.txt
+          {
+            echo '<!-- terraform-pr-gate -->'
+            echo '### Terraform remote-state plan'
+            echo
+            printf -- '- Source SHA: `%s`\n' "$SOURCE_SHA"
+            printf -- '- Backend prefix: `%s`\n' "$BACKEND_PREFIX"
+            printf -- '- Change counts: `%s`\n' "$(head -n 1 infra/terraform/plan-evidence.txt)"
+            echo
+            echo '| Resource address | Actions |'
+            echo '| --- | --- |'
+            tail -n +2 infra/terraform/plan-evidence.txt | while IFS=$'\t' read -r address actions; do
+              printf '| `%s` | `%s` |\n' "$address" "$actions"
+            done
+          } > infra/terraform/plan-comment.md
+          cat infra/terraform/plan-comment.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update sanitized pull-request comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          comment_id="$(gh api "repos/$REPOSITORY/issues/$PR_NUMBER/comments" --paginate \
+            --jq '.[] | select(.user.type == "Bot" and (.body | startswith("<!-- terraform-pr-gate -->"))) | .id' \
+            | head -n 1)"
+          if [ -n "$comment_id" ]; then
+            gh api --method PATCH "repos/$REPOSITORY/issues/comments/$comment_id" \
+              --raw-field body="$(cat infra/terraform/plan-comment.md)" >/dev/null
+          else
+            gh api --method POST "repos/$REPOSITORY/issues/$PR_NUMBER/comments" \
+              --raw-field body="$(cat infra/terraform/plan-comment.md)" >/dev/null
+          fi
+
+      - name: Delete all plan material
+        if: always()
+        run: rm -f infra/terraform/tfplan.out infra/terraform/tfplan.json infra/terraform/plan-evidence.txt infra/terraform/plan-comment.md
+
+  gate:
+    name: Terraform Gate
+    if: always()
+    needs: [changes, validate, plan]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Enforce validation, eligibility, and remote plan
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          VALIDATE_RESULT: ${{ needs.validate.result }}
+          PLAN_RESULT: ${{ needs.plan.result }}
+          TERRAFORM_CHANGED: ${{ needs.changes.outputs.terraform }}
+          SAME_REPOSITORY: ${{ needs.changes.outputs.same_repository }}
+        run: |
+          set -euo pipefail
+          test "$CHANGES_RESULT" = "success"
+          test "$VALIDATE_RESULT" = "success"
+          if [ "$TERRAFORM_CHANGED" = "true" ]; then
+            test "$SAME_REPOSITORY" = "true"
+            test "$PLAN_RESULT" = "success"
+          else
+            test "$PLAN_RESULT" = "skipped"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,10 +84,12 @@ See [`docs/architecture/ai-features.md`](docs/architecture/ai-features.md).
 
 - Pin third-party GitHub Actions to full commit SHAs with readable version comments.
 - Use supported Node versions and least job permissions; keep policy validation blocking.
-- PR Terraform plans are review evidence only and are never apply input.
-- Main checks out exact `GITHUB_SHA`, creates a saved plan, and applies that same file.
+- Every PR runs credential-free Terraform validation; same-repository trust changes add a sanitized,
+  read-only remote plan. A protected `main` merge is the sole apply authorization.
+- Main verifies exact `GITHUB_SHA`, creates a fresh locked plan, and applies that same local file.
 - Terraform planning, apply, and application deployment use distinct WIF identities.
-- Apply runs behind the protected `production` GitHub environment.
+- Apply uses the main-only `terraform-apply` environment for scoped credentials, without a second
+  reviewer gate; production application deployment remains manual.
 - The API image is multi-stage, production-only, digest-pinned, and non-root.
 - Provider settings and production activation require external verification.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,10 +84,12 @@ See [`docs/architecture/ai-features.md`](docs/architecture/ai-features.md).
 
 - Pin third-party GitHub Actions to full commit SHAs with readable version comments.
 - Use supported Node versions and least job permissions; keep policy validation blocking.
-- PR Terraform plans are review evidence only and are never apply input.
-- Main checks out exact `GITHUB_SHA`, creates a saved plan, and applies that same file.
+- Every PR runs credential-free Terraform validation; same-repository trust changes add a sanitized,
+  read-only remote plan. A protected `main` merge is the sole apply authorization.
+- Main verifies exact `GITHUB_SHA`, creates a fresh locked plan, and applies that same local file.
 - Terraform planning, apply, and application deployment use distinct WIF identities.
-- Apply runs behind the protected `production` GitHub environment.
+- Apply uses the main-only `terraform-apply` environment for scoped credentials, without a second
+  reviewer gate; production application deployment remains manual.
 - The API image is multi-stage, production-only, digest-pinned, and non-root.
 - Provider settings and production activation require external verification.
 

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -35,18 +35,25 @@ occur after partial mutation, so the next fresh plan is the recovery record.
 
 Each capability has a distinct pool, provider, service account, and exact OIDC subject:
 
-| Capability      | Exact subject                                                          | Intended authority                                                               |
-| --------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| PR plan         | `repo:briananderson-xyz/briananderson-xyz:pull_request`                | Metadata reads and `roles/storage.objectViewer` on the exact backend bucket only |
-| Image publish   | `repo:briananderson-xyz/briananderson-xyz:ref:refs/heads/main`         | Writer on the `site-functions` repository                                        |
-| Dev deploy      | `repo:briananderson-xyz/briananderson-xyz:environment:dev`             | Dev services, bucket, runtime `actAs`, and image reads                           |
-| Prod deploy     | `repo:briananderson-xyz/briananderson-xyz:environment:prod`            | Equivalent production-only resources                                             |
-| Terraform apply | `repo:briananderson-xyz/briananderson-xyz:environment:terraform-apply` | Infrastructure administration after a reviewed merge                             |
+| Capability      | Exact subject                                                          | Intended authority                                                   |
+| --------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| PR plan         | `repo:briananderson-xyz/briananderson-xyz:pull_request`                | Metadata reads, state-object reads, and bucket-IAM policy reads only |
+| Image publish   | `repo:briananderson-xyz/briananderson-xyz:ref:refs/heads/main`         | Writer on the `site-functions` repository                            |
+| Dev deploy      | `repo:briananderson-xyz/briananderson-xyz:environment:dev`             | Dev services, bucket, runtime `actAs`, and image reads               |
+| Prod deploy     | `repo:briananderson-xyz/briananderson-xyz:environment:prod`            | Equivalent production-only resources                                 |
+| Terraform apply | `repo:briananderson-xyz/briananderson-xyz:environment:terraform-apply` | Infrastructure administration after a reviewed merge                 |
 
 Provider conditions also require the exact repository, event type, branch where applicable, and
 allowed owner ID. Bindings use exact `principal://.../subject/...` members; repository-wide
 `principalSet` grants are forbidden. The planner has no project-level Storage role and no mutation
 role. Publisher, dev, prod, and apply cannot impersonate one another.
+
+Terraform refreshes the IAM resources on the production site, dev site, and state buckets during a
+remote plan. The planner therefore receives a custom role containing only
+`storage.buckets.getIamPolicy`, bound separately at those three managed buckets. It has no
+`storage.buckets.setIamPolicy`, object-write, object-delete, Storage Admin, or project-level binding.
+The state bucket separately grants `roles/storage.objectViewer` so the backend can read state
+objects at the exact backend bucket only.
 
 Dev/prod may read images only from `site-functions`; publisher alone writes them. Cloud Run rollout
 uses resource-level `roles/run.developer` and preserves service IAM. A trusted administrator must

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -1,131 +1,125 @@
 # GCP infrastructure and GitHub trust
 
-This Terraform configuration manages the static-site buckets, API image repository, runtime
-service accounts and secrets, and the GitHub workload identity boundary.
+This directory manages the static-site buckets, API repository, runtime identities and secrets, and
+the GitHub workload identity boundary. Terraform state can contain secrets; never publish state,
+raw plan JSON, saved binary plans, outputs, or before/after values.
 
-## Release safety
+## Delivery contract
 
-- Pull requests run `fmt`, backend-disabled `init`, `validate`, and static policy checks without a
-  Google credential, repository secret, remote backend, saved plan, or write permission.
-- Merging Terraform changes does not run Terraform apply. The apply workflow is manual-only,
-  requires the exact current `main` SHA plus `APPLY_TERRAFORM`, and uses the protected
-  `terraform-apply` environment.
-- Apply creates and consumes one saved plan in one job. An `always()` step deletes the binary and
-  no workflow uploads it.
-- This source change does not modify live IAM. Remote planning and application deployment stay
-  disabled until a trusted administrator completes and verifies the bootstrap below.
+A reviewed pull request is the Terraform production gate:
+
+1. Every PR to `main` runs the stable `Terraform Gate`. Credential-free format, backend-disabled
+   initialization, validation, and policy tests always run, even when Terraform did not change.
+2. A same-repository PR that changes Terraform or its trust workflows also authenticates as the
+   read-only planner, reads the exact backend bucket with `-lock=false`, and creates a local plan.
+   Forked Terraform changes fail closed.
+3. PR evidence is a sanitized evidence manifest containing only the exact source SHA, backend
+   prefix, add/change/destroy counts, resource addresses, and action arrays. The job updates one bot
+   comment and its summary, then deletes the plan, raw JSON, and text files. Nothing is uploaded.
+4. Merging the reviewed PR to protected `main` automatically starts one non-cancelling,
+   backend-serialized apply job. It verifies that `GITHUB_SHA` is the current `origin/main`, creates
+   a fresh locked saved plan against current state, and applies that exact local file in the same
+   job. There is no dispatch input, confirmation string, downloaded PR plan, or second approval.
+5. Production application deployment remains a separate manual-only workflow. Terraform delivery
+   never dispatches it.
+
+The authenticated PR plan executes code from the branch with read access to sensitive state. This
+design assumes same-repository branches are controlled by the trusted owner. If write access is
+expanded, add a protected planning approval boundary before allowing those contributors to plan.
+
+If automatic apply fails, do not rerun blindly. Inspect state and live IAM, confirm the backend is
+unlocked, and submit a reviewed corrective or revert PR through this same path. A provider error can
+occur after partial mutation, so the next fresh plan is the recovery record.
 
 ## Trust domains
 
-Each capability has a separate pool, provider, service account, and exact GitHub OIDC subject:
+Each capability has a distinct pool, provider, service account, and exact OIDC subject:
 
-| Capability | Required subject | Maximum intended authority |
-| --- | --- | --- |
-| Review plan | `repo:briananderson-xyz/briananderson-xyz:pull_request` | Resource metadata reads; optional exact state-bucket object reads |
-| Image publish | `repo:briananderson-xyz/briananderson-xyz:ref:refs/heads/main` | Artifact Registry writer on `site-functions` |
-| Dev deploy | `repo:briananderson-xyz/briananderson-xyz:environment:dev` | Dev bucket objects, dev services, dev runtime `actAs`, `site-functions` image reads |
-| Prod deploy | `repo:briananderson-xyz/briananderson-xyz:environment:prod` | Prod bucket objects, prod services, prod runtime `actAs`, `site-functions` image reads |
-| Terraform apply | `repo:briananderson-xyz/briananderson-xyz:environment:terraform-apply` | Infrastructure administration |
+| Capability      | Exact subject                                                          | Intended authority                                                               |
+| --------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| PR plan         | `repo:briananderson-xyz/briananderson-xyz:pull_request`                | Metadata reads and `roles/storage.objectViewer` on the exact backend bucket only |
+| Image publish   | `repo:briananderson-xyz/briananderson-xyz:ref:refs/heads/main`         | Writer on the `site-functions` repository                                        |
+| Dev deploy      | `repo:briananderson-xyz/briananderson-xyz:environment:dev`             | Dev services, bucket, runtime `actAs`, and image reads                           |
+| Prod deploy     | `repo:briananderson-xyz/briananderson-xyz:environment:prod`            | Equivalent production-only resources                                             |
+| Terraform apply | `repo:briananderson-xyz/briananderson-xyz:environment:terraform-apply` | Infrastructure administration after a reviewed merge                             |
 
-Bindings use `principal://.../subject/...`, never a repository or pool-wide `principalSet`. The
-publisher cannot deploy; dev cannot act as the production runtime or update production storage;
-and no automatic workflow subject can impersonate the production deployer or Terraform applier.
-Dev and prod can read images only from the `site-functions` Artifact Registry repository; neither
-identity can publish images or receives a project-wide Artifact Registry role.
-Cloud Run deployer IAM is resource-level and source-disabled by default. Set
-`manage_deployment_service_iam=true` only after verifying that every configured service exists and
-reviewing the authenticated state-backed plan.
+Provider conditions also require the exact repository, event type, branch where applicable, and
+allowed owner ID. Bindings use exact `principal://.../subject/...` members; repository-wide
+`principalSet` grants are forbidden. The planner has no project-level Storage role and no mutation
+role. Publisher, dev, prod, and apply cannot impersonate one another.
 
-Routine Cloud Run image rollouts use `roles/run.developer` and preserve each service's existing IAM
-policy. They do not create or repair public access. A trusted administrator must separately grant
-`allUsers` the `roles/run.invoker` role on each intended public service as an explicitly reviewed
-service-IAM/bootstrap operation. Existing public invoker IAM and live service reachability remain
-externally `NOT_VERIFIED`; never add IAM-mutating deploy flags as a shortcut.
+Dev/prod may read images only from `site-functions`; publisher alone writes them. Cloud Run rollout
+uses resource-level `roles/run.developer` and preserves service IAM. A trusted administrator must
+separately grant `allUsers` `roles/run.invoker` for an intended public service. Both PR and apply
+pass `manage_deployment_service_iam=true` so they plan with identical, verified service-IAM inputs.
 
-## Credential-free local validation
+## Credential-free validation
 
-This is the same class of check used on pull requests and does not contact the configured backend:
+Run from this directory:
 
 ```bash
+set -euo pipefail
 terraform fmt -check -recursive
-TF_DATA_DIR="$(mktemp -d)" terraform init -backend=false -lockfile=readonly
-TF_DATA_DIR="$(mktemp -d)" terraform validate -no-color
+TF_DATA_DIR="$(mktemp -d)"
+export TF_DATA_DIR
+trap 'rm -rf "$TF_DATA_DIR"' EXIT
+terraform init -backend=false -lockfile=readonly
+terraform validate -no-color
 ./check-policy.sh
+./test-check-policy.sh
 ```
 
-Run those commands from this directory. Provider installation may contact the Terraform Registry;
-it does not authenticate to GCP or inspect live state.
+Provider installation may contact the Terraform Registry but does not inspect GCP state.
 
-## Trusted-administrator bootstrap
+## One-time bootstrap
 
-Bootstrap is a separately approved infrastructure operation. Do not perform it as part of an
-application delivery or merely because these source files changed.
+The initial creation of the separated identities is the unavoidable local trust root because the
+new apply identity cannot create itself. Perform this once as a named administrator from reviewed
+source; it is not routine delivery authorization.
 
-1. Authenticate locally as a named administrator through the organization's approved GCP path.
-2. Confirm the active project and account. Initialize the real backend with the expected bucket and
-   `gcp/infra` prefix.
-3. Inspect current state and import any already-existing identity resources needed to prevent
-   replacement surprises. There is intentionally no generic import helper: derive every address and
-   provider ID from the reviewed current inventory. Review the migration away from the retired
-   shared pool and deployer.
-4. Create a saved, narrow trust-boundary plan using explicit values for project, region, repository,
-   and buckets. Do not use a GitHub workflow or an identity being created by that plan.
-5. Inspect the full state-backed plan. Confirm five distinct pools/providers/accounts, exact-subject
-   bindings, deletion of shared CI grants, resource-level deploy grants, and no unrelated change.
-6. Only after separate human approval, the administrator may apply that exact reviewed plan. This
-   repository change neither performs nor authorizes that apply.
-7. Populate environment/repository credentials from Terraform outputs:
-   - publisher: `GCP_WIF_PUBLISHER_PROVIDER`, `GCP_WIF_PUBLISHER_SA_EMAIL`
-   - dev: `GCP_WIF_DEV_PROVIDER`, `GCP_WIF_DEV_SA_EMAIL`
-   - prod: `GCP_WIF_PROD_PROVIDER`, `GCP_WIF_PROD_SA_EMAIL`
-   - apply environment: `GCP_WIF_APPLY_PROVIDER`, `GCP_WIF_APPLY_SA_EMAIL`
-   - optional review planning: `GCP_WIF_PLAN_PROVIDER`, `GCP_WIF_PLAN_SA_EMAIL`
-8. Protect `dev`, `prod`, and `terraform-apply` environments as appropriate. Keep production and
-   apply manual-only. Do not configure legacy `GCP_WIF_PROVIDER` / `GCP_WIF_SA_EMAIL` fallbacks.
-9. From representative PR, main, and dev OIDC subjects, verify impersonation of the production and
-   apply service accounts is denied. Verify the publisher cannot deploy and dev cannot mutate the
-   production bucket or act as the production runtime.
-10. Verify a dev-only deployment against the named dev services, then set the repository variable
-    `DEV_DEPLOY_ENABLED=true`. Until that proof exists, automatic cloud jobs must skip safely.
+1. Confirm the authenticated account, project `briananderson-xyz-468620`, state bucket
+   `briananderson-xyz-tf-state`, prefix `gcp/infra`, current `main`, and live resource inventory.
+   Keep a local state backup and all saved plans in a mode-`0700` directory outside the repository.
+2. Initialize the real backend and create a normal full saved plan with explicit project, region,
+   bucket, repository, state bucket, and `manage_deployment_service_iam=true` values.
+3. From its JSON, mechanically select only addresses whose action is exactly `create`. Generate a
+   second create-only targeted saved plan from those addresses. Abort unless it has zero update,
+   delete, replace, service-image, data, bucket, secret, or unrelated application actions.
+4. Review and apply that exact reviewed plan locally. This targeted bootstrap is the only exception;
+   routine plans must never use `-target`.
+5. After IAM propagation, run a complete non-applying plan. It may show only the separately reviewed
+   legacy identity/grant removals. Do not remove legacy access until the new PR plan and main apply
+   identities authenticate successfully.
 
-### Optional read-only remote planning
+Before the cleanup merge, rollback means removing the new GitHub settings while retaining legacy
+access. After cleanup, rollback is a reviewed revert PR; never recreate a broad shared identity ad
+hoc.
 
-Credential-free pull-request `fmt`, backend-disabled `init`, `validate`, and policy checks are the
-required merge checks. Authenticated remote planning is optional and manual. Terraform state can
-contain secrets, so the plan service account receives no project-level storage role in this
-configuration.
+## GitHub settings and activation order
 
-If remote planning is needed, use this separate **external bootstrap**:
+Populate values from Terraform outputs without printing them:
 
-1. A trusted administrator selects the exact existing GCS state bucket after confirming its project,
-   name, and backend prefix.
-2. At that bucket only, grant the plan service account `roles/storage.objectViewer`. Do not grant a
-   project-level storage role or access to any other bucket.
-3. Keep remote `terraform plan` read-only and use `-lock=false`; never apply from the planning
-   identity and never upload the resulting plan file as an artifact.
-4. Verify the plan service account can read the required state object but cannot list or read an
-   unrelated bucket and cannot create, replace, or delete state objects.
-5. Record the bucket-level IAM binding and those negative checks as provider evidence before enabling
-   a manual remote-plan workflow.
+- Repository secrets: `GCP_WIF_PLAN_PROVIDER`, `GCP_WIF_PLAN_SA_EMAIL`,
+  `GCP_WIF_PUBLISHER_PROVIDER`, `GCP_WIF_PUBLISHER_SA_EMAIL`, and `TF_STATE_BUCKET` for planning.
+- Repository variables: `GCP_PROJECT_ID`, `GCP_REGION`, and `SITE_BUCKET_NAME`.
+- `dev` secrets: `GCP_WIF_DEV_PROVIDER`, `GCP_WIF_DEV_SA_EMAIL`, and existing dev-only application
+  values. Restrict deployment branches to `main`.
+- `terraform-apply` secrets: `GCP_WIF_APPLY_PROVIDER`, `GCP_WIF_APPLY_SA_EMAIL`, and
+  `TF_STATE_BUCKET`. Restrict deployment branches to `main` and configure no reviewer gate.
+- `prod` secrets: `GCP_WIF_PROD_PROVIDER` and `GCP_WIF_PROD_SA_EMAIL`. Keep the environment and
+  application deployment workflow manual/protected.
 
-The exact state bucket, its object grant, remote state contents, and negative permission checks are
-externally `NOT_VERIFIED` until that evidence is recorded.
+Do not configure legacy `GCP_WIF_PROVIDER` or `GCP_WIF_SA_EMAIL` fallbacks. Install branch
+protection only after observing the exact successful `Terraform Gate` context: require PRs,
+up-to-date checks, conversation resolution, and disallow force pushes/deletion.
 
-The authenticated plan, live IAM bindings, environment protections, secret placement, negative
-impersonation tests, and actual dev deployment remain externally `NOT_VERIFIED` by source checks.
+Keep `DEV_DEPLOY_ENABLED` absent or false until planner/apply/publisher/dev authentication, negative
+cross-identity probes, dev DNS/origin routing, rollback digests, and public invoker policy are all
+verified. Then set it to `true` immediately before one controlled `main` proof. On failure, set it
+false and use the recorded prior digest/static build rollback. Production must remain untouched.
 
-## Provider decision
+## Provider baseline
 
-The reviewed baseline is Terraform `1.15.x` and `hashicorp/google` `5.45.2`. The lockfile records
-that exact provider. A Google provider 7 migration is deferred to a dedicated, authenticated
-infrastructure change because a provider-major upgrade requires remote-state schema review and a
-separately approved plan. Do not combine it with application delivery or run `init -upgrade`
-casually.
-
-## Manual apply mechanics
-
-The `Terraform Apply (manual)` workflow accepts only the 40-character SHA currently at the tip of
-`main` and the exact confirmation `APPLY_TERRAFORM`. The protected environment supplies backend,
-project, region, bucket, and apply-only WIF configuration. The job checks out that SHA, proves it is
-the current remote main tip, plans it, applies the same local binary, and deletes the binary even on
-failure. It never consumes PR output or an artifact from another run.
+Terraform is `1.15.x`; `hashicorp/google` is locked to `5.45.2`. A provider-major upgrade requires a
+separate authenticated state/schema review and PR. Never combine it with bootstrap or run
+`init -upgrade` casually.

--- a/infra/terraform/check-policy.sh
+++ b/infra/terraform/check-policy.sh
@@ -220,6 +220,24 @@ if awk '
   exit 1
 fi
 
+assert_plan_project_iam_binding() {
+  local resource_name="$1"
+  local expected_role="$2"
+  local block
+
+  block="$(awk -v resource_name="$resource_name" '
+    $0 == "resource \"google_project_iam_member\" \"" resource_name "\" {" { capture = 1 }
+    capture { print }
+    /^}/ && capture { exit }
+  ' "$root/infra/terraform/main.tf")"
+  contains_fixed 'project = var.project_id' <(printf '%s\n' "$block")
+  contains_fixed "role    = \"$expected_role\"" <(printf '%s\n' "$block")
+  contains_fixed 'member  = "serviceAccount:${google_service_account.plan.email}"' <(printf '%s\n' "$block")
+}
+
+assert_plan_project_iam_binding plan_viewer roles/viewer
+assert_plan_project_iam_binding plan_secret_viewer roles/secretmanager.viewer
+
 contains_fixed 'variable "terraform_state_bucket"' "$root/infra/terraform/variables.tf"
 contains_fixed 'default     = "briananderson-xyz-tf-state"' "$root/infra/terraform/variables.tf"
 state_reader_block="$(awk '
@@ -230,6 +248,93 @@ state_reader_block="$(awk '
 contains_fixed 'bucket = var.terraform_state_bucket' <(printf '%s\n' "$state_reader_block")
 contains_fixed 'role   = "roles/storage.objectViewer"' <(printf '%s\n' "$state_reader_block")
 contains_fixed 'member = "serviceAccount:${google_service_account.plan.email}"' <(printf '%s\n' "$state_reader_block")
+
+bucket_iam_role_block="$(awk '
+  /^resource "google_project_iam_custom_role" "plan_bucket_iam_reader"/ { capture = 1 }
+  capture { print }
+  /^}/ && capture { exit }
+' "$root/infra/terraform/main.tf")"
+contains_fixed 'permissions = ["storage.buckets.getIamPolicy"]' <(printf '%s\n' "$bucket_iam_role_block")
+if report_regex 'storage\.buckets\.setIamPolicy|storage\.objects\.|roles/storage\.(admin|objectAdmin)' \
+  <(printf '%s\n' "$bucket_iam_role_block"); then
+  echo "The planner bucket-IAM custom role must remain read-only and object-blind." >&2
+  exit 1
+fi
+
+assert_plan_bucket_iam_binding() {
+  local resource_name="$1"
+  local expected_bucket="$2"
+  local block
+
+  block="$(awk -v resource_name="$resource_name" '
+    $0 == "resource \"google_storage_bucket_iam_member\" \"" resource_name "\" {" { capture = 1 }
+    capture { print }
+    /^}/ && capture { exit }
+  ' "$root/infra/terraform/main.tf")"
+  contains_fixed "bucket = $expected_bucket" <(printf '%s\n' "$block")
+  contains_fixed 'role   = google_project_iam_custom_role.plan_bucket_iam_reader.name' <(printf '%s\n' "$block")
+  contains_fixed 'member = "serviceAccount:${google_service_account.plan.email}"' <(printf '%s\n' "$block")
+}
+
+assert_plan_bucket_iam_binding plan_site_bucket_iam_reader google_storage_bucket.site.name
+assert_plan_bucket_iam_binding plan_site_dev_bucket_iam_reader google_storage_bucket.site_dev.name
+assert_plan_bucket_iam_binding plan_state_bucket_iam_reader var.terraform_state_bucket
+
+if [ "$(awk '/role[[:space:]]*= google_project_iam_custom_role\.plan_bucket_iam_reader\.name/ { count++ } END { print count + 0 }' "$root/infra/terraform/main.tf")" -ne 3 ]; then
+  echo "The planner bucket-IAM role must be bound to exactly the site, dev-site, and state buckets." >&2
+  exit 1
+fi
+
+# Inventory every Terraform resource block across every .tf file that grants
+# authority to the planner. Header allowlisting prevents an additive role,
+# resource type, bucket, or second custom-role binding from bypassing the
+# named-block assertions above.
+planner_iam_inventory="$(awk '
+  function brace_delta(line, copy, opens, closes) {
+    copy = line
+    opens = gsub(/{/, "{", copy)
+    copy = line
+    closes = gsub(/}/, "}", copy)
+    return opens - closes
+  }
+  function finish_block() {
+    if (block ~ /google_service_account\.plan\.email/) {
+      print header
+    }
+    capture = 0
+    depth = 0
+    header = ""
+    block = ""
+  }
+  /^resource "/ {
+    if (capture) finish_block()
+    capture = 1
+    header = $0
+    block = $0 ORS
+    depth = brace_delta($0)
+    if (depth == 0) finish_block()
+    next
+  }
+  capture {
+    block = block $0 ORS
+    depth += brace_delta($0)
+    if (depth == 0) finish_block()
+  }
+  END {
+    if (capture) finish_block()
+  }
+' "$root/infra/terraform"/*.tf | LC_ALL=C sort)"
+expected_planner_iam_inventory='resource "google_project_iam_member" "plan_secret_viewer" {
+resource "google_project_iam_member" "plan_viewer" {
+resource "google_storage_bucket_iam_member" "plan_site_bucket_iam_reader" {
+resource "google_storage_bucket_iam_member" "plan_site_dev_bucket_iam_reader" {
+resource "google_storage_bucket_iam_member" "plan_state_bucket_iam_reader" {
+resource "google_storage_bucket_iam_member" "plan_state_reader" {'
+if [ "$planner_iam_inventory" != "$expected_planner_iam_inventory" ]; then
+  echo "Planner IAM inventory differs from the exact six-grant allowlist." >&2
+  printf 'Observed planner IAM resources:\n%s\n' "$planner_iam_inventory" >&2
+  exit 1
+fi
 
 for identity_event in \
   'plan:pull_request' \
@@ -248,6 +353,8 @@ done
 for required in \
   'create-only targeted saved plan' \
   'roles/storage.objectViewer' \
+  'storage.buckets.getIamPolicy' \
+  'three managed buckets' \
   'exact backend bucket only' \
   'Terraform state can contain secrets' \
   'sanitized evidence' \

--- a/infra/terraform/check-policy.sh
+++ b/infra/terraform/check-policy.sh
@@ -197,8 +197,7 @@ if report_regex "${legacy_identity}|${legacy_writer}|${legacy_run_admin}" \
   exit 1
 fi
 
-if report_regex 'run .?terraform apply|terraform apply[[:space:]]+-auto-approve' \
-  "$root/infra/terraform/README.md"; then
+if report_regex 'terraform apply[[:space:]]+-auto-approve' "$root/infra/terraform/README.md"; then
   echo "Bootstrap guidance cannot recommend an unreviewed direct apply." >&2
   exit 1
 fi
@@ -221,13 +220,38 @@ if awk '
   exit 1
 fi
 
+contains_fixed 'variable "terraform_state_bucket"' "$root/infra/terraform/variables.tf"
+contains_fixed 'default     = "briananderson-xyz-tf-state"' "$root/infra/terraform/variables.tf"
+state_reader_block="$(awk '
+  /^resource "google_storage_bucket_iam_member" "plan_state_reader"/ { capture = 1 }
+  capture { print }
+  /^}/ && capture { exit }
+' "$root/infra/terraform/main.tf")"
+contains_fixed 'bucket = var.terraform_state_bucket' <(printf '%s\n' "$state_reader_block")
+contains_fixed 'role   = "roles/storage.objectViewer"' <(printf '%s\n' "$state_reader_block")
+contains_fixed 'member = "serviceAccount:${google_service_account.plan.email}"' <(printf '%s\n' "$state_reader_block")
+
+for identity_event in \
+  'plan:pull_request' \
+  'publisher:push' \
+  'dev:push' \
+  'prod:workflow_dispatch' \
+  'apply:push'; do
+  identity="${identity_event%%:*}"
+  event="${identity_event#*:}"
+  contains_regex "attribute_condition.*local\\.wif_subjects\\.${identity}.*assertion\\.repository ==.*assertion\\.event_name == '${event}'" "$root/infra/terraform/main.tf"
+done
+for identity in publisher dev prod apply; do
+  contains_regex "attribute_condition.*local\\.wif_subjects\\.${identity}.*assertion\\.ref == 'refs/heads/" "$root/infra/terraform/main.tf"
+done
+
 for required in \
-  'external bootstrap' \
+  'create-only targeted saved plan' \
   'roles/storage.objectViewer' \
-  'At that bucket only' \
-  'Terraform state can' \
-  'contain secrets' \
-  'externally `NOT_VERIFIED`'; do
+  'exact backend bucket only' \
+  'Terraform state can contain secrets' \
+  'sanitized evidence' \
+  'automatic apply'; do
   contains_fixed "$required" "$root/infra/terraform/README.md"
 done
 
@@ -301,13 +325,75 @@ contains_regex '^    environment: dev$' "$workflows/build-and-deploy.yml"
 contains_regex '^    environment: prod$' "$workflows/deploy-production.yml"
 contains_regex '^    environment: terraform-apply$' "$workflows/terraform-apply.yml"
 
-if report_regex '^[[:space:]]+(push|pull_request|schedule):' "$workflows/terraform-apply.yml"; then
-  echo "Terraform apply must remain workflow_dispatch-only." >&2
+contains_fixed 'name: Terraform Gate' "$workflows/terraform-pr.yml"
+contains_regex '^  pull_request:$' "$workflows/terraform-pr.yml"
+if report_regex '^[[:space:]]+paths:' "$workflows/terraform-pr.yml"; then
+  echo "The stable Terraform PR gate must run for every pull request to main." >&2
+  exit 1
+fi
+contains_fixed 'same_repository: ${{ steps.diff.outputs.same_repository }}' "$workflows/terraform-pr.yml"
+contains_fixed "HEAD_REPOSITORY: \${{ github.event.pull_request.head.repo.full_name }}" "$workflows/terraform-pr.yml"
+contains_fixed "if: needs.changes.outputs.terraform == 'true' && needs.changes.outputs.same_repository == 'true'" "$workflows/terraform-pr.yml"
+contains_fixed "test \"\$SAME_REPOSITORY\" = \"true\"" "$workflows/terraform-pr.yml"
+
+validate_block="$(awk '
+  /^  validate:/ { capture = 1 }
+  /^  plan:/ { capture = 0 }
+  capture { print }
+' "$workflows/terraform-pr.yml")"
+if report_regex 'id-token|google-github-actions/auth|secrets\.' <(printf '%s\n' "$validate_block"); then
+  echo "The always-running Terraform PR validation job must remain credential-free." >&2
+  exit 1
+fi
+contains_fixed '-lock=false' "$workflows/terraform-pr.yml"
+contains_fixed '-var="manage_deployment_service_iam=true"' "$workflows/terraform-pr.yml"
+contains_fixed '-var="manage_deployment_service_iam=true"' "$workflows/terraform-apply.yml"
+contains_fixed 'terraform -chdir=infra/terraform show -json tfplan.out > infra/terraform/tfplan.json' "$workflows/terraform-pr.yml"
+contains_fixed 'infra/terraform/sanitize-plan-evidence.sh' "$workflows/terraform-pr.yml"
+if report_regex '\.resource_changes|\.change\.actions|sort_by\(\.address\)' "$workflows/terraform-pr.yml"; then
+  echo "The PR workflow must use the behavior-tested sanitizer instead of an inline transformation." >&2
+  exit 1
+fi
+for executable in \
+  "$root/infra/terraform/check-policy.sh" \
+  "$root/infra/terraform/test-check-policy.sh" \
+  "$root/infra/terraform/sanitize-plan-evidence.sh" \
+  "$root/infra/terraform/test-sanitize-plan-evidence.sh"; do
+  if [ ! -x "$executable" ]; then
+    echo "Terraform policy and sanitizer scripts must be executable: $executable" >&2
+    exit 1
+  fi
+done
+contains_fixed 'Resource address | Actions' "$workflows/terraform-pr.yml"
+contains_fixed 'Source SHA:' "$workflows/terraform-pr.yml"
+contains_fixed 'Backend prefix:' "$workflows/terraform-pr.yml"
+contains_fixed 'Change counts:' "$workflows/terraform-pr.yml"
+contains_fixed 'Delete all plan material' "$workflows/terraform-pr.yml" "$workflows/terraform-apply.yml"
+
+if report_regex 'actions/(upload|download)-artifact|\.before|\.after|\.planned_values|\.prior_state' "$workflows/terraform-pr.yml"; then
+  echo "PR planning cannot publish binary plans, raw values, or state-shaped JSON." >&2
   exit 1
 fi
 
-if report_regex 'id-token|google-github-actions/auth|secrets\.' "$workflows/terraform-pr.yml"; then
-  echo "Required Terraform PR validation must remain credential-free." >&2
+contains_regex '^  push:$' "$workflows/terraform-apply.yml"
+if report_regex 'workflow_dispatch|inputs\.|APPLY_TERRAFORM|confirmation' "$workflows/terraform-apply.yml"; then
+  echo "A reviewed main merge must be the only Terraform apply gate." >&2
+  exit 1
+fi
+contains_fixed 'group: terraform-backend-gcp-infra' "$workflows/terraform-apply.yml"
+contains_fixed 'cancel-in-progress: false' "$workflows/terraform-apply.yml"
+contains_fixed 'SOURCE_SHA: ${{ github.sha }}' "$workflows/terraform-apply.yml"
+contains_fixed 'refs/remotes/origin/main' "$workflows/terraform-apply.yml"
+contains_fixed 'Create fresh locked plan for this main SHA' "$workflows/terraform-apply.yml"
+contains_fixed 'Apply the same fresh saved plan' "$workflows/terraform-apply.yml"
+if report_regex 'actions/(upload|download)-artifact|workflow_run' "$workflows/terraform-apply.yml"; then
+  echo "Automatic apply must create and consume its own local saved plan." >&2
+  exit 1
+fi
+
+contains_regex '^  workflow_dispatch:$' "$workflows/deploy-production.yml"
+if report_regex '^[[:space:]]+(push|pull_request|schedule):' "$workflows/deploy-production.yml"; then
+  echo "Production application deployment must remain manual-only." >&2
   exit 1
 fi
 

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -96,7 +96,7 @@ resource "google_iam_workload_identity_pool_provider" "plan" {
   workload_identity_pool_provider_id = var.wif_plan_provider_id
   display_name                       = "Terraform Plan"
   attribute_mapping                  = { "google.subject" = "assertion.sub" }
-  attribute_condition                = "assertion.sub == '${local.wif_subjects.plan}' && assertion.repository_owner_id in ${jsonencode(var.allowed_repository_owner_ids)}"
+  attribute_condition                = "assertion.sub == '${local.wif_subjects.plan}' && assertion.repository == '${var.github_org}/${var.github_repo}' && assertion.event_name == 'pull_request' && assertion.repository_owner_id in ${jsonencode(var.allowed_repository_owner_ids)}"
   oidc { issuer_uri = "https://token.actions.githubusercontent.com" }
 }
 
@@ -105,7 +105,7 @@ resource "google_iam_workload_identity_pool_provider" "publisher" {
   workload_identity_pool_provider_id = var.wif_publisher_provider_id
   display_name                       = "Artifact Publisher"
   attribute_mapping                  = { "google.subject" = "assertion.sub" }
-  attribute_condition                = "assertion.sub == '${local.wif_subjects.publisher}' && assertion.repository_owner_id in ${jsonencode(var.allowed_repository_owner_ids)}"
+  attribute_condition                = "assertion.sub == '${local.wif_subjects.publisher}' && assertion.repository == '${var.github_org}/${var.github_repo}' && assertion.event_name == 'push' && assertion.ref == 'refs/heads/${var.github_branch}' && assertion.repository_owner_id in ${jsonencode(var.allowed_repository_owner_ids)}"
   oidc { issuer_uri = "https://token.actions.githubusercontent.com" }
 }
 
@@ -114,7 +114,7 @@ resource "google_iam_workload_identity_pool_provider" "dev" {
   workload_identity_pool_provider_id = var.wif_dev_provider_id
   display_name                       = "Dev Deploy"
   attribute_mapping                  = { "google.subject" = "assertion.sub" }
-  attribute_condition                = "assertion.sub == '${local.wif_subjects.dev}' && assertion.repository_owner_id in ${jsonencode(var.allowed_repository_owner_ids)}"
+  attribute_condition                = "assertion.sub == '${local.wif_subjects.dev}' && assertion.repository == '${var.github_org}/${var.github_repo}' && assertion.event_name == 'push' && assertion.ref == 'refs/heads/${var.github_branch}' && assertion.repository_owner_id in ${jsonencode(var.allowed_repository_owner_ids)}"
   oidc { issuer_uri = "https://token.actions.githubusercontent.com" }
 }
 
@@ -123,7 +123,7 @@ resource "google_iam_workload_identity_pool_provider" "prod" {
   workload_identity_pool_provider_id = var.wif_prod_provider_id
   display_name                       = "Prod Deploy"
   attribute_mapping                  = { "google.subject" = "assertion.sub" }
-  attribute_condition                = "assertion.sub == '${local.wif_subjects.prod}' && assertion.repository_owner_id in ${jsonencode(var.allowed_repository_owner_ids)}"
+  attribute_condition                = "assertion.sub == '${local.wif_subjects.prod}' && assertion.repository == '${var.github_org}/${var.github_repo}' && assertion.event_name == 'workflow_dispatch' && assertion.ref == 'refs/heads/${var.github_branch}' && assertion.repository_owner_id in ${jsonencode(var.allowed_repository_owner_ids)}"
   oidc { issuer_uri = "https://token.actions.githubusercontent.com" }
 }
 
@@ -132,7 +132,7 @@ resource "google_iam_workload_identity_pool_provider" "apply" {
   workload_identity_pool_provider_id = var.wif_apply_provider_id
   display_name                       = "Terraform Apply"
   attribute_mapping                  = { "google.subject" = "assertion.sub" }
-  attribute_condition                = "assertion.sub == '${local.wif_subjects.apply}' && assertion.repository_owner_id in ${jsonencode(var.allowed_repository_owner_ids)}"
+  attribute_condition                = "assertion.sub == '${local.wif_subjects.apply}' && assertion.repository == '${var.github_org}/${var.github_repo}' && assertion.event_name == 'push' && assertion.ref == 'refs/heads/${var.github_branch}' && assertion.repository_owner_id in ${jsonencode(var.allowed_repository_owner_ids)}"
   oidc { issuer_uri = "https://token.actions.githubusercontent.com" }
 }
 
@@ -193,8 +193,7 @@ resource "google_service_account_iam_member" "wif_apply" {
   member             = "principal://iam.googleapis.com/${google_iam_workload_identity_pool.apply.name}/subject/${local.wif_subjects.apply}"
 }
 
-# Planning requires resource metadata reads, but no mutation roles. Optional
-# remote-state access is an exact-bucket external bootstrap described in README.
+# Planning requires resource metadata reads, but no mutation roles.
 resource "google_project_iam_member" "plan_viewer" {
   project = var.project_id
   role    = "roles/viewer"
@@ -205,6 +204,14 @@ resource "google_project_iam_member" "plan_secret_viewer" {
   project = var.project_id
   role    = "roles/secretmanager.viewer"
   member  = "serviceAccount:${google_service_account.plan.email}"
+}
+
+# Remote planning can read only the configured backend bucket. This must never
+# become a project-level Storage grant or a write-capable bucket role.
+resource "google_storage_bucket_iam_member" "plan_state_reader" {
+  bucket = var.terraform_state_bucket
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.plan.email}"
 }
 
 # The applier is separate from the application deployer. These roles cover the

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -206,6 +206,35 @@ resource "google_project_iam_member" "plan_secret_viewer" {
   member  = "serviceAccount:${google_service_account.plan.email}"
 }
 
+# Terraform refreshes bucket IAM resources during planning. This custom role
+# exposes only the IAM-policy read required for that refresh; it cannot change
+# bucket IAM or read/write objects.
+resource "google_project_iam_custom_role" "plan_bucket_iam_reader" {
+  project     = var.project_id
+  role_id     = "terraformPlanBucketIamReader"
+  title       = "Terraform Plan Bucket IAM Reader"
+  description = "Read bucket IAM policies required by the Terraform planner"
+  permissions = ["storage.buckets.getIamPolicy"]
+}
+
+resource "google_storage_bucket_iam_member" "plan_site_bucket_iam_reader" {
+  bucket = google_storage_bucket.site.name
+  role   = google_project_iam_custom_role.plan_bucket_iam_reader.name
+  member = "serviceAccount:${google_service_account.plan.email}"
+}
+
+resource "google_storage_bucket_iam_member" "plan_site_dev_bucket_iam_reader" {
+  bucket = google_storage_bucket.site_dev.name
+  role   = google_project_iam_custom_role.plan_bucket_iam_reader.name
+  member = "serviceAccount:${google_service_account.plan.email}"
+}
+
+resource "google_storage_bucket_iam_member" "plan_state_bucket_iam_reader" {
+  bucket = var.terraform_state_bucket
+  role   = google_project_iam_custom_role.plan_bucket_iam_reader.name
+  member = "serviceAccount:${google_service_account.plan.email}"
+}
+
 # Remote planning can read only the configured backend bucket. This must never
 # become a project-level Storage grant or a write-capable bucket role.
 resource "google_storage_bucket_iam_member" "plan_state_reader" {

--- a/infra/terraform/sanitize-plan-evidence.sh
+++ b/infra/terraform/sanitize-plan-evidence.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 INPUT_PLAN_JSON OUTPUT_EVIDENCE" >&2
+  exit 64
+fi
+
+input="$1"
+output="$2"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required to sanitize Terraform plan evidence." >&2
+  exit 69
+fi
+if [ ! -f "$input" ]; then
+  echo "Input plan JSON must be a regular file." >&2
+  exit 66
+fi
+
+output_dir="$(dirname "$output")"
+if [ ! -d "$output_dir" ]; then
+  echo "Output directory does not exist." >&2
+  exit 73
+fi
+
+input_path="$(cd "$(dirname "$input")" && pwd -P)/$(basename "$input")"
+output_path="$(cd "$output_dir" && pwd -P)/$(basename "$output")"
+if [ "$input_path" = "$output_path" ] || { [ -e "$output" ] && [ "$input" -ef "$output" ]; }; then
+  echo "Input and output paths must not alias." >&2
+  exit 65
+fi
+
+temporary="$(mktemp "${output_path}.tmp.XXXXXX")"
+trap 'rm -f "$temporary"' EXIT
+
+jq -er '
+  if type != "object" or (.resource_changes | type) != "array" then
+    error("resource_changes must be an array")
+  else
+    [.resource_changes[] | {address, actions: .change.actions}]
+  end
+  | if any(.[]; (.address | type) != "string") then
+      error("every resource address must be a string")
+    elif (map(.address) | length) != (map(.address) | unique | length) then
+      error("resource addresses must be unique")
+    elif any(.[]; (.address | test("^[A-Za-z0-9_.\\[\\]\\\"/-]+$") | not)) then
+      error("resource address contains forbidden characters")
+    elif any(.[]; (.actions | type) != "array" or (.actions | length) == 0) then
+      error("every action set must be a non-empty array")
+    elif any(.[]; any(.actions[]; type != "string" or (IN("no-op", "create", "read", "update", "delete") | not))) then
+      error("action is not allowlisted")
+    else
+      .
+    end
+  | "add=" + ([.[] | select(.actions | index("create"))] | length | tostring)
+      + " change=" + ([.[] | select(.actions | index("update"))] | length | tostring)
+      + " destroy=" + ([.[] | select(.actions | index("delete"))] | length | tostring),
+    (sort_by(.address)[] | [.address, (.actions | join("+"))] | @tsv)
+' "$input" >"$temporary"
+
+mv -f "$temporary" "$output_path"
+trap - EXIT

--- a/infra/terraform/test-check-policy.sh
+++ b/infra/terraform/test-check-policy.sh
@@ -54,6 +54,12 @@ expect_policy_failure() {
 
 expect_policy_failure state-write-role \
   "sed -i.bak 's/role   = \"roles\/storage.objectViewer\"/role   = \"roles\/storage.objectAdmin\"/' \"\$1/infra/terraform/main.tf\""
+expect_policy_failure bucket-iam-write-permission \
+  "sed -i.bak 's/storage.buckets.getIamPolicy/storage.buckets.setIamPolicy/' \"\$1/infra/terraform/main.tf\""
+expect_policy_failure additive-object-admin-binding \
+  "printf '\nresource \"google_storage_bucket_iam_member\" \"rogue_plan_object_admin\" {\n  bucket = google_storage_bucket.site.name\n  role = \"roles/storage.objectAdmin\"\n  member = \"serviceAccount:\${google_service_account.plan.email}\"\n}\n' >> \"\$1/infra/terraform/cloud-run.tf\""
+expect_policy_failure additive-custom-iam-writer \
+  "printf '\nresource \"google_project_iam_custom_role\" \"rogue_plan_iam_writer\" {\n  project = var.project_id\n  role_id = \"roguePlanIamWriter\"\n  title = \"Rogue planner IAM writer\"\n  permissions = [\"storage.buckets.setIamPolicy\"]\n}\nresource \"google_storage_bucket_iam_member\" \"rogue_plan_iam_writer\" {\n  bucket = google_storage_bucket.site.name\n  role = google_project_iam_custom_role.rogue_plan_iam_writer.name\n  member = \"serviceAccount:\${google_service_account.plan.email}\"\n}\n' >> \"\$1/infra/terraform/services.tf\""
 expect_policy_failure project-storage-role \
   "printf '\nresource \"google_project_iam_member\" \"bad_plan_storage\" {\n  project = var.project_id\n  role = \"roles/storage.objectViewer\"\n  member = \"serviceAccount:\${google_service_account.plan.email}\"\n}\n' >> \"\$1/infra/terraform/main.tf\""
 expect_policy_failure repository-wide-pr-plan \

--- a/infra/terraform/test-check-policy.sh
+++ b/infra/terraform/test-check-policy.sh
@@ -7,6 +7,7 @@ standard_path="/usr/bin:/bin"
 
 # Exercise the preferred search implementation when ripgrep is installed.
 "$policy"
+"$root/infra/terraform/test-sanitize-plan-evidence.sh"
 
 # GitHub's Ubuntu runner does not guarantee ripgrep, so exercise the grep fallback too.
 PATH="$standard_path" "$policy"
@@ -30,4 +31,40 @@ if [ "$status" -ne 73 ]; then
 fi
 
 grep -Fq 'Policy search failed while checking for forbidden text.' "$test_dir/stderr"
+
+expect_policy_failure() {
+  local label="$1"
+  local mutation="$2"
+  local fixture="$test_dir/$label"
+
+  mkdir -p "$fixture/infra" "$fixture/.github"
+  cp -R "$root/infra/terraform" "$fixture/infra/terraform"
+  cp -R "$root/.github/workflows" "$fixture/.github/workflows"
+  sh -c "$mutation" sh "$fixture"
+
+  set +e
+  "$fixture/infra/terraform/check-policy.sh" >"$fixture/stdout" 2>"$fixture/stderr"
+  local status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "Expected policy-negative fixture '$label' to fail closed." >&2
+    exit 1
+  fi
+}
+
+expect_policy_failure state-write-role \
+  "sed -i.bak 's/role   = \"roles\/storage.objectViewer\"/role   = \"roles\/storage.objectAdmin\"/' \"\$1/infra/terraform/main.tf\""
+expect_policy_failure project-storage-role \
+  "printf '\nresource \"google_project_iam_member\" \"bad_plan_storage\" {\n  project = var.project_id\n  role = \"roles/storage.objectViewer\"\n  member = \"serviceAccount:\${google_service_account.plan.email}\"\n}\n' >> \"\$1/infra/terraform/main.tf\""
+expect_policy_failure repository-wide-pr-plan \
+  "sed -i.bak 's/ && needs.changes.outputs.same_repository == '\"'\"'true'\"'\"'//' \"\$1/.github/workflows/terraform-pr.yml\""
+expect_policy_failure plan-artifact-upload \
+  "printf '\n# actions/upload-artifact@forbidden\n' >> \"\$1/.github/workflows/terraform-pr.yml\""
+expect_policy_failure manual-apply-gate \
+  "sed -i.bak 's/^  push:/  workflow_dispatch:/' \"\$1/.github/workflows/terraform-apply.yml\""
+expect_policy_failure cancelling-apply \
+  "sed -i.bak 's/cancel-in-progress: false/cancel-in-progress: true/' \"\$1/.github/workflows/terraform-apply.yml\""
+expect_policy_failure implicit-service-iam \
+  "sed -i.bak 's/manage_deployment_service_iam=true/manage_deployment_service_iam=false/g' \"\$1/.github/workflows/terraform-pr.yml\""
+
 echo "Terraform policy search portability tests passed."

--- a/infra/terraform/test-sanitize-plan-evidence.sh
+++ b/infra/terraform/test-sanitize-plan-evidence.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+sanitizer="$root/sanitize-plan-evidence.sh"
+test_dir="$(mktemp -d)"
+trap 'rm -rf "$test_dir"' EXIT
+
+cat >"$test_dir/plan.json" <<'JSON'
+{
+  "format_version": "SENTINEL_TOP_LEVEL",
+  "provider_config": {"secret": "SENTINEL_PROVIDER"},
+  "output_changes": {"token": {"after": "SENTINEL_OUTPUT"}},
+  "diagnostics": ["SENTINEL_DIAGNOSTIC"],
+  "resource_changes": [
+    {
+      "address": "module.site.google_storage_bucket.example[\"dev\"]",
+      "private": "SENTINEL_PRIVATE",
+      "change": {
+        "actions": ["update"],
+        "before": {"password": "SENTINEL_BEFORE"},
+        "after": {"password": "SENTINEL_AFTER"},
+        "before_sensitive": {"password": true},
+        "after_sensitive": {"password": true},
+        "unrelated": "SENTINEL_NESTED"
+      }
+    },
+    {
+      "address": "google_service_account.example",
+      "change": {
+        "actions": ["delete", "create"],
+        "before": "SENTINEL_REPLACED_BEFORE",
+        "after": "SENTINEL_REPLACED_AFTER"
+      }
+    }
+  ],
+  "arbitrary": "SENTINEL_ARBITRARY"
+}
+JSON
+
+cat >"$test_dir/expected.txt" <<'TEXT'
+add=1 change=1 destroy=1
+google_service_account.example	delete+create
+module.site.google_storage_bucket.example["dev"]	update
+TEXT
+
+"$sanitizer" "$test_dir/plan.json" "$test_dir/evidence.txt"
+diff -u "$test_dir/expected.txt" "$test_dir/evidence.txt"
+
+if grep -Eq 'SENTINEL_|before|after|sensitive|output_changes|diagnostics|provider_config|arbitrary|private' \
+  "$test_dir/evidence.txt"; then
+  echo "Sanitized evidence leaked a forbidden field or value." >&2
+  exit 1
+fi
+
+cat >"$test_dir/invalid.json" <<'JSON'
+{"resource_changes":[{"address":"safe.resource","change":{"actions":["execute"]}}]}
+JSON
+printf 'MUST_NOT_SURVIVE\n' >"$test_dir/invalid-output.txt"
+if "$sanitizer" "$test_dir/invalid.json" "$test_dir/invalid-output.txt" >/dev/null 2>&1; then
+  echo "Unknown Terraform actions must fail closed." >&2
+  exit 1
+fi
+if [ -e "$test_dir/invalid-output.txt" ] && ! grep -Fxq 'MUST_NOT_SURVIVE' "$test_dir/invalid-output.txt"; then
+  echo "A failed sanitization modified its output." >&2
+  exit 1
+fi
+
+if "$sanitizer" "$test_dir/plan.json" "$test_dir/plan.json" >/dev/null 2>&1; then
+  echo "Aliased input/output paths must fail closed." >&2
+  exit 1
+fi
+
+echo "Terraform plan evidence sanitizer tests passed."

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -39,6 +39,11 @@ variable "wif_plan_sa_name" {
   type    = string
   default = "github-terraform-planner"
 }
+variable "terraform_state_bucket" {
+  description = "Exact GCS bucket containing the Terraform backend state"
+  type        = string
+  default     = "briananderson-xyz-tf-state"
+}
 variable "wif_publisher_pool_id" {
   type    = string
   default = "github-publisher-pool"

--- a/site/scripts/validate-delivery-workflows.mjs
+++ b/site/scripts/validate-delivery-workflows.mjs
@@ -7,6 +7,8 @@ const siteRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const repoRoot = resolve(siteRoot, "..");
 const automaticPath = join(repoRoot, ".github", "workflows", "build-and-deploy.yml");
 const productionPath = join(repoRoot, ".github", "workflows", "deploy-production.yml");
+const terraformPrPath = join(repoRoot, ".github", "workflows", "terraform-pr.yml");
+const terraformApplyPath = join(repoRoot, ".github", "workflows", "terraform-apply.yml");
 const failures = [];
 
 async function loadWorkflow(path) {
@@ -27,14 +29,24 @@ function acceptsProductionBinding({ sourceSha, imageRef, tagDigest }) {
 
 const automatic = await loadWorkflow(automaticPath);
 const production = await loadWorkflow(productionPath);
+const terraformPr = await loadWorkflow(terraformPrPath);
+const terraformApply = await loadWorkflow(terraformApplyPath);
 const automaticOn = automatic.workflow.on;
 const productionOn = production.workflow.on;
+const terraformPrOn = terraformPr.workflow.on;
+const terraformApplyOn = terraformApply.workflow.on;
 
 expect(Boolean(automaticOn?.push), "automatic workflow must run on push");
 expect(!automaticOn?.workflow_dispatch, "automatic workflow must not expose workflow_dispatch");
-expect(!automaticOn?.pull_request && !automaticOn?.schedule, "automatic workflow must be push-only");
+expect(
+  !automaticOn?.pull_request && !automaticOn?.schedule,
+  "automatic workflow must be push-only"
+);
 expect(Boolean(automatic.workflow.jobs?.validate), "automatic workflow must retain validation");
-expect(Boolean(automatic.workflow.jobs?.["build-functions"]), "automatic workflow must test the container without credentials");
+expect(
+  Boolean(automatic.workflow.jobs?.["build-functions"]),
+  "automatic workflow must test the container without credentials"
+);
 
 const validationEnv = automatic.workflow.jobs?.validate?.steps?.find(
   (step) => step?.name === "Validate site"
@@ -85,20 +97,35 @@ for (const forbidden of [
   "gs://briananderson.xyz",
   "api.briananderson.xyz"
 ]) {
-  expect(!automatic.source.includes(forbidden), `automatic workflow contains forbidden production or legacy token: ${forbidden}`);
+  expect(
+    !automatic.source.includes(forbidden),
+    `automatic workflow contains forbidden production or legacy token: ${forbidden}`
+  );
 }
 
 expect(automatic.source.includes("GCP_WIF_PUBLISHER_PROVIDER"), "publisher identity is missing");
 expect(automatic.source.includes("GCP_WIF_DEV_PROVIDER"), "dev identity is missing");
-expect(automatic.source.includes("containerimage.digest"), "registry-confirmed build metadata digest is missing");
-expect(automatic.source.includes("docker buildx imagetools inspect"), "registry digest confirmation is missing");
+expect(
+  automatic.source.includes("containerimage.digest"),
+  "registry-confirmed build metadata digest is missing"
+);
+expect(
+  automatic.source.includes("docker buildx imagetools inspect"),
+  "registry digest confirmation is missing"
+);
 expect(
   automatic.source.includes('IMAGE_TAG="${IMAGE_NAME}:${GITHUB_SHA}"'),
   "publisher must publish the image under the full GITHUB_SHA tag"
 );
-expect(!automatic.source.includes("GITHUB_SHA:0:8"), "publisher must not shorten the source SHA tag");
+expect(
+  !automatic.source.includes("GITHUB_SHA:0:8"),
+  "publisher must not shorten the source SHA tag"
+);
 expect(!automatic.source.includes("dev-stable"), "mutable dev-stable deployment is forbidden");
-expect(automatic.source.includes('--image "$IMAGE_REF"'), "dev deploys must consume IMAGE_REF by digest");
+expect(
+  automatic.source.includes('--image "$IMAGE_REF"'),
+  "dev deploys must consume IMAGE_REF by digest"
+);
 expect(
   !automatic.source.includes("--allow-unauthenticated"),
   "routine dev deployment must preserve service IAM instead of granting public access"
@@ -119,17 +146,32 @@ for (const jobName of ["publish-functions", "deploy-functions-dev", "deploy-site
 }
 
 expect(Boolean(productionOn?.workflow_dispatch), "production workflow must be manual-only");
-expect(!productionOn?.push && !productionOn?.pull_request && !productionOn?.schedule, "production workflow has an automatic trigger");
+expect(
+  !productionOn?.push && !productionOn?.pull_request && !productionOn?.schedule,
+  "production workflow has an automatic trigger"
+);
 for (const input of ["confirmation", "source_sha", "image_ref"]) {
   const definition = productionOn?.workflow_dispatch?.inputs?.[input];
   expect(definition?.required === true, `production ${input} input must be required`);
   expect(definition?.type === "string", `production ${input} input must be typed as string`);
 }
-expect(production.source.includes('"DEPLOY_PRODUCTION"'), "production workflow must require exact confirmation");
-expect(production.source.includes("@sha256:[0-9a-f]{64}"), "production workflow must validate an immutable image digest");
+expect(
+  production.source.includes('"DEPLOY_PRODUCTION"'),
+  "production workflow must require exact confirmation"
+);
+expect(
+  production.source.includes("@sha256:[0-9a-f]{64}"),
+  "production workflow must validate an immutable image digest"
+);
 expect(production.source.includes("GCP_WIF_PROD_PROVIDER"), "production-only identity is missing");
-expect(!production.source.includes("GCP_WIF_DEV_") && !production.source.includes("GCP_WIF_PUBLISHER_"), "production workflow must not use dev or publisher identities");
-expect(production.source.includes("EXPECTED_PREFIX"), "production image must be constrained to the configured registry path");
+expect(
+  !production.source.includes("GCP_WIF_DEV_") && !production.source.includes("GCP_WIF_PUBLISHER_"),
+  "production workflow must not use dev or publisher identities"
+);
+expect(
+  production.source.includes("EXPECTED_PREFIX"),
+  "production image must be constrained to the configured registry path"
+);
 expect(
   production.source.includes("refs/remotes/origin/main") &&
     production.source.includes('= "$SOURCE_SHA"'),
@@ -151,8 +193,12 @@ expect(
   production.source.includes('[ "$TAG_DIGEST" = "$EXPECTED_DIGEST" ]'),
   "production preflight must require the full source SHA tag digest to equal image_ref"
 );
-const tagResolutionIndex = production.source.indexOf('gcloud artifacts docker images describe "$FULL_SHA_TAG"');
-const provenanceComparisonIndex = production.source.indexOf('[ "$TAG_DIGEST" = "$EXPECTED_DIGEST" ]');
+const tagResolutionIndex = production.source.indexOf(
+  'gcloud artifacts docker images describe "$FULL_SHA_TAG"'
+);
+const provenanceComparisonIndex = production.source.indexOf(
+  '[ "$TAG_DIGEST" = "$EXPECTED_DIGEST" ]'
+);
 const cloudRunReadIndex = production.source.indexOf("gcloud run services describe");
 const staticMutationIndex = production.source.indexOf("gcloud storage rsync");
 expect(
@@ -169,7 +215,11 @@ const fixtureSha = "a".repeat(40);
 const fixtureDigest = `sha256:${"b".repeat(64)}`;
 const fixtureImage = `us-central1-docker.pkg.dev/example/site-functions/api@${fixtureDigest}`;
 expect(
-  acceptsProductionBinding({ sourceSha: fixtureSha, imageRef: fixtureImage, tagDigest: fixtureDigest }),
+  acceptsProductionBinding({
+    sourceSha: fixtureSha,
+    imageRef: fixtureImage,
+    tagDigest: fixtureDigest
+  }),
   "production provenance positive fixture must be accepted"
 );
 expect(
@@ -195,10 +245,83 @@ for (const [jobName, job] of Object.entries(production.workflow.jobs ?? {})) {
   }
 }
 
+expect(Boolean(terraformPrOn?.pull_request), "Terraform PR gate must run on pull requests");
+expect(
+  terraformPrOn?.pull_request?.paths === undefined,
+  "Terraform PR gate must not use path filters"
+);
+expect(
+  Boolean(terraformPr.workflow.jobs?.validate),
+  "Terraform PR gate needs credential-free validation"
+);
+expect(Boolean(terraformPr.workflow.jobs?.plan), "Terraform PR gate needs authenticated planning");
+expect(
+  terraformPr.workflow.jobs?.gate?.name === "Terraform Gate",
+  "Terraform aggregate gate must retain its stable name"
+);
+const terraformValidate = JSON.stringify(terraformPr.workflow.jobs?.validate ?? {});
+expect(
+  !/id-token|google-github-actions\/auth|secrets\./.test(terraformValidate),
+  "Terraform validation job must remain credential-free"
+);
+expect(
+  String(terraformPr.workflow.jobs?.plan?.if ?? "").includes("same_repository == 'true'"),
+  "Terraform remote plan must be restricted to same-repository pull requests"
+);
+expect(terraformPr.source.includes("-lock=false"), "Terraform PR plan must not lock remote state");
+expect(
+  terraformPr.source.includes("manage_deployment_service_iam=true"),
+  "Terraform PR plan must explicitly include deployment-service IAM"
+);
+expect(
+  terraformPr.source.includes("infra/terraform/sanitize-plan-evidence.sh"),
+  "Terraform PR evidence must use the behavior-tested sanitizer"
+);
+expect(
+  !/actions\/(?:upload|download)-artifact|\.before|\.after|\.planned_values|\.prior_state/.test(
+    terraformPr.source
+  ),
+  "Terraform PR evidence must not expose plans, state-shaped values, or raw plan structures"
+);
+
+expect(Boolean(terraformApplyOn?.push), "Terraform apply must run automatically after main merge");
+expect(
+  !terraformApplyOn?.workflow_dispatch &&
+    !terraformApplyOn?.pull_request &&
+    !terraformApplyOn?.schedule,
+  "Terraform apply must have no second manual or non-main trigger"
+);
+expect(
+  terraformApply.workflow.concurrency?.["cancel-in-progress"] === false,
+  "Terraform apply serialization must not cancel an in-flight backend operation"
+);
+expect(
+  terraformApply.source.includes("refs/remotes/origin/main") &&
+    terraformApply.source.includes("SOURCE_SHA: ${{ github.sha }}"),
+  "Terraform apply must verify the exact current main SHA"
+);
+expect(
+  terraformApply.source.includes("Create fresh locked plan for this main SHA") &&
+    terraformApply.source.includes("Apply the same fresh saved plan"),
+  "Terraform apply must create and consume one fresh local saved plan"
+);
+expect(
+  terraformApply.source.includes("manage_deployment_service_iam=true"),
+  "Terraform apply must use the same explicit deployment-service IAM input as PR planning"
+);
+expect(
+  !/actions\/(?:upload|download)-artifact|workflow_run|APPLY_TERRAFORM|confirmation/.test(
+    terraformApply.source
+  ),
+  "Terraform apply must not consume PR artifacts or require a second manual gate"
+);
+
 if (failures.length > 0) {
   console.error("Delivery workflow policy validation failed:\n");
   failures.forEach((failure) => console.error(`- ${failure}`));
   process.exit(1);
 }
 
-console.log("Delivery workflows validated: push-only dev automation and manual immutable production deployment.");
+console.log(
+  "Delivery workflows validated: PR-gated Terraform apply, push-only dev automation, and manual immutable production deployment."
+);


### PR DESCRIPTION
## What changed

- restores authenticated, state-backed Terraform plans on pull requests using a plan-only WIF identity
- makes merge to `main` the sole Terraform apply gate; apply creates and consumes one fresh locked plan for the exact merged SHA
- separates plan, artifact publisher, dev deployer, production deployer, and Terraform apply identities
- publishes only sanitized plan counts and resource address/action rows
- keeps production application deployment manual and keeps dev deployment disabled until post-merge verification

## Expected Terraform plan

The bootstrapped split identities are already present. The authenticated PR plan should show only 12 deletions for the superseded legacy shared identity and its bindings, with no creates, updates, or replacements.

## Verification

- full `pnpm run validate` passed
- Terraform fmt/init/validate passed
- policy and hostile sanitizer fixtures passed
- code and security re-review passed
- create-only bootstrap proved 42/42 intended resources present
- canonical post-bootstrap plan: 12 deletes, 0 creates, 0 updates, 0 replacements

## Safety boundary

- no production application deployment is triggered by this PR
- `DEV_DEPLOY_ENABLED` remains unset
- legacy GitHub secrets remain until the automatic post-merge Terraform apply succeeds