### PR TITLE
Allow Terraform applier to manage custom roles

### DIFF
--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -54,6 +54,7 @@ jobs:
           fi
 
   validate:
+    name: Terraform Validate
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -65,6 +66,22 @@ jobs:
 
       - name: Verify checked out revision
         run: test "$(git rev-parse HEAD)" = "${{ github.event.pull_request.head.sha }}"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+        with:
+          version: 10.33.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 22
+          cache: "pnpm"
+          cache-dependency-path: site/pnpm-lock.yaml
+
+      - name: Install workflow-policy dependencies
+        working-directory: site
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
@@ -82,6 +99,10 @@ jobs:
 
       - name: Trust-boundary policy and hostile-path tests
         run: infra/terraform/test-check-policy.sh
+
+      - name: Validate parsed delivery workflows
+        working-directory: site
+        run: pnpm run test:delivery-policy
 
   plan:
     needs: changes

--- a/.github/workflows/validate-ui.yml
+++ b/.github/workflows/validate-ui.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: ["main"]
-    paths:
-      - "site/**"
-      - ".github/workflows/**"
-      - ".gitignore"
   workflow_dispatch:
 
 concurrency:
@@ -18,6 +14,7 @@ concurrency:
 
 jobs:
   validate:
+    name: UI Validate
     if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
@@ -64,6 +61,10 @@ jobs:
       - name: Validate GitHub Actions policy
         working-directory: site
         run: pnpm run test:workflow-policy
+
+      - name: Validate delivery workflow semantics
+        working-directory: site
+        run: pnpm run test:delivery-policy
 
       - name: Run unit tests
         working-directory: site

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -55,6 +55,10 @@ remote plan. The planner therefore receives a custom role containing only
 The state bucket separately grants `roles/storage.objectViewer` so the backend can read state
 objects at the exact backend bucket only.
 
+The apply identity alone receives `roles/iam.roleAdmin` because Terraform manages the planner's
+custom bucket-IAM reader role and must read, create, update, or retire that role after a reviewed
+merge. Planner, publisher, dev, and production deployment identities never receive Role Admin.
+
 Dev/prod may read images only from `site-functions`; publisher alone writes them. Cloud Run rollout
 uses resource-level `roles/run.developer` and preserves service IAM. A trusted administrator must
 separately grant `allUsers` `roles/run.invoker` for an intended public service. Both PR and apply

--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -121,8 +121,11 @@ Populate values from Terraform outputs without printing them:
   application deployment workflow manual/protected.
 
 Do not configure legacy `GCP_WIF_PROVIDER` or `GCP_WIF_SA_EMAIL` fallbacks. Install branch
-protection only after observing the exact successful `Terraform Gate` context: require PRs,
-up-to-date checks, conversation resolution, and disallow force pushes/deletion.
+protection only after observing the exact successful `Terraform Gate` and `UI Validate` contexts:
+require PRs, up-to-date checks, conversation resolution, and disallow force pushes/deletion.
+`Terraform Validate` is deliberately distinct from `UI Validate`, so one workflow can never satisfy
+the other's required check. Both PR validation jobs execute the parsed delivery-workflow validator,
+so invalid trigger or job-name semantics fail before merge.
 
 Keep `DEV_DEPLOY_ENABLED` absent or false until planner/apply/publisher/dev authentication, negative
 cross-identity probes, dev DNS/origin routing, rollback digests, and public invoker policy are all

--- a/infra/terraform/check-policy.sh
+++ b/infra/terraform/check-policy.sh
@@ -450,10 +450,13 @@ contains_regex '^    environment: dev$' "$workflows/build-and-deploy.yml"
 contains_regex '^    environment: prod$' "$workflows/deploy-production.yml"
 contains_regex '^    environment: terraform-apply$' "$workflows/terraform-apply.yml"
 
-contains_fixed 'name: Terraform Gate' "$workflows/terraform-pr.yml"
 contains_regex '^  pull_request:$' "$workflows/terraform-pr.yml"
 if report_regex '^[[:space:]]+paths:' "$workflows/terraform-pr.yml"; then
   echo "The stable Terraform PR gate must run for every pull request to main." >&2
+  exit 1
+fi
+if report_regex '^[[:space:]]+paths:' "$workflows/validate-ui.yml"; then
+  echo "The stable UI validation check must run for every pull request to main." >&2
   exit 1
 fi
 contains_fixed 'same_repository: ${{ steps.diff.outputs.same_repository }}' "$workflows/terraform-pr.yml"
@@ -466,10 +469,23 @@ validate_block="$(awk '
   /^  plan:/ { capture = 0 }
   capture { print }
 ' "$workflows/terraform-pr.yml")"
+contains_fixed '    name: Terraform Validate' <(printf '%s\n' "$validate_block")
+contains_fixed 'pnpm run test:delivery-policy' <(printf '%s\n' "$validate_block")
 if report_regex 'id-token|google-github-actions/auth|secrets\.' <(printf '%s\n' "$validate_block"); then
   echo "The always-running Terraform PR validation job must remain credential-free." >&2
   exit 1
 fi
+gate_block="$(awk '
+  /^  gate:/ { capture = 1 }
+  capture { print }
+' "$workflows/terraform-pr.yml")"
+contains_fixed '    name: Terraform Gate' <(printf '%s\n' "$gate_block")
+ui_validate_block="$(awk '
+  /^  validate:/ { capture = 1 }
+  capture { print }
+' "$workflows/validate-ui.yml")"
+contains_fixed '    name: UI Validate' <(printf '%s\n' "$ui_validate_block")
+contains_fixed 'pnpm run test:delivery-policy' <(printf '%s\n' "$ui_validate_block")
 contains_fixed '-lock=false' "$workflows/terraform-pr.yml"
 contains_fixed '-var="manage_deployment_service_iam=true"' "$workflows/terraform-pr.yml"
 contains_fixed '-var="manage_deployment_service_iam=true"' "$workflows/terraform-apply.yml"

--- a/infra/terraform/check-policy.sh
+++ b/infra/terraform/check-policy.sh
@@ -365,6 +365,24 @@ done
 # Project-wide Cloud Run administration is reserved for the manual Terraform
 # applier. Automatic publisher/dev/prod identities receive only narrow grants.
 contains_fixed '"roles/run.admin"' "$root/infra/terraform/main.tf"
+terraform_apply_roles_block="$(awk '
+  /terraform_apply_roles = toset\(\[/ { capture = 1 }
+  capture { print }
+  /^[[:space:]]*\]\)$/ && capture { exit }
+' "$root/infra/terraform/main.tf")"
+contains_fixed 'terraform_apply_roles = toset([' <(printf '%s\n' "$terraform_apply_roles_block")
+contains_fixed '"roles/iam.roleAdmin"' <(printf '%s\n' "$terraform_apply_roles_block")
+terraform_apply_block="$(awk '
+  /^resource "google_project_iam_member" "terraform_apply"/ { capture = 1 }
+  capture { print }
+  /^}/ && capture { exit }
+' "$root/infra/terraform/main.tf")"
+contains_fixed 'for_each = local.terraform_apply_roles' <(printf '%s\n' "$terraform_apply_block")
+contains_fixed 'member  = "serviceAccount:${google_service_account.apply.email}"' <(printf '%s\n' "$terraform_apply_block")
+if [ "$(awk '/roles\/iam\.roleAdmin/ { count++ } END { print count + 0 }' "$root/infra/terraform"/*.tf)" -ne 1 ]; then
+  echo "roles/iam.roleAdmin must appear exactly once in Terraform source and remain apply-only." >&2
+  exit 1
+fi
 if report_regex 'roles/run\.admin' "$root/infra/terraform/cloud-run.tf"; then
   echo "Application delivery identities cannot receive project-wide Cloud Run admin." >&2
   exit 1

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -248,6 +248,7 @@ resource "google_storage_bucket_iam_member" "plan_state_reader" {
 locals {
   terraform_apply_roles = toset([
     "roles/artifactregistry.admin",
+    "roles/iam.roleAdmin",
     "roles/iam.serviceAccountAdmin",
     "roles/iam.workloadIdentityPoolAdmin",
     "roles/resourcemanager.projectIamAdmin",

--- a/infra/terraform/test-check-policy.sh
+++ b/infra/terraform/test-check-policy.sh
@@ -78,5 +78,7 @@ expect_policy_failure cancelling-apply \
   "sed -i.bak 's/cancel-in-progress: false/cancel-in-progress: true/' \"\$1/.github/workflows/terraform-apply.yml\""
 expect_policy_failure implicit-service-iam \
   "sed -i.bak 's/manage_deployment_service_iam=true/manage_deployment_service_iam=false/g' \"\$1/.github/workflows/terraform-pr.yml\""
+expect_policy_failure terraform-job-name-shadowed-by-step \
+  "sed -i.bak 's/^    name: Terraform Validate$/    name: UI Validate/' \"\$1/.github/workflows/terraform-pr.yml\""
 
 echo "Terraform policy search portability tests passed."

--- a/infra/terraform/test-check-policy.sh
+++ b/infra/terraform/test-check-policy.sh
@@ -60,6 +60,12 @@ expect_policy_failure additive-object-admin-binding \
   "printf '\nresource \"google_storage_bucket_iam_member\" \"rogue_plan_object_admin\" {\n  bucket = google_storage_bucket.site.name\n  role = \"roles/storage.objectAdmin\"\n  member = \"serviceAccount:\${google_service_account.plan.email}\"\n}\n' >> \"\$1/infra/terraform/cloud-run.tf\""
 expect_policy_failure additive-custom-iam-writer \
   "printf '\nresource \"google_project_iam_custom_role\" \"rogue_plan_iam_writer\" {\n  project = var.project_id\n  role_id = \"roguePlanIamWriter\"\n  title = \"Rogue planner IAM writer\"\n  permissions = [\"storage.buckets.setIamPolicy\"]\n}\nresource \"google_storage_bucket_iam_member\" \"rogue_plan_iam_writer\" {\n  bucket = google_storage_bucket.site.name\n  role = google_project_iam_custom_role.rogue_plan_iam_writer.name\n  member = \"serviceAccount:\${google_service_account.plan.email}\"\n}\n' >> \"\$1/infra/terraform/services.tf\""
+expect_policy_failure missing-apply-role-admin \
+  "sed -i.bak '/\"roles\/iam.roleAdmin\",/d' \"\$1/infra/terraform/main.tf\""
+expect_policy_failure shared-apply-role-admin \
+  "printf '\nresource \"google_project_iam_member\" \"rogue_dev_role_admin\" {\n  project = var.project_id\n  role = \"roles/iam.roleAdmin\"\n  member = \"serviceAccount:\${google_service_account.dev.email}\"\n}\n' >> \"\$1/infra/terraform/services.tf\""
+expect_policy_failure relocated-apply-role-admin \
+  "sed -i.bak '/\"roles\/iam.roleAdmin\",/d' \"\$1/infra/terraform/main.tf\"; printf '\nresource \"google_project_iam_member\" \"rogue_only_dev_role_admin\" {\n  project = var.project_id\n  role = \"roles/iam.roleAdmin\"\n  member = \"serviceAccount:\${google_service_account.dev.email}\"\n}\n' >> \"\$1/infra/terraform/services.tf\""
 expect_policy_failure project-storage-role \
   "printf '\nresource \"google_project_iam_member\" \"bad_plan_storage\" {\n  project = var.project_id\n  role = \"roles/storage.objectViewer\"\n  member = \"serviceAccount:\${google_service_account.plan.email}\"\n}\n' >> \"\$1/infra/terraform/main.tf\""
 expect_policy_failure repository-wide-pr-plan \

--- a/site/scripts/validate-delivery-workflows.mjs
+++ b/site/scripts/validate-delivery-workflows.mjs
@@ -9,6 +9,7 @@ const automaticPath = join(repoRoot, ".github", "workflows", "build-and-deploy.y
 const productionPath = join(repoRoot, ".github", "workflows", "deploy-production.yml");
 const terraformPrPath = join(repoRoot, ".github", "workflows", "terraform-pr.yml");
 const terraformApplyPath = join(repoRoot, ".github", "workflows", "terraform-apply.yml");
+const uiValidatePath = join(repoRoot, ".github", "workflows", "validate-ui.yml");
 const failures = [];
 
 async function loadWorkflow(path) {
@@ -31,10 +32,12 @@ const automatic = await loadWorkflow(automaticPath);
 const production = await loadWorkflow(productionPath);
 const terraformPr = await loadWorkflow(terraformPrPath);
 const terraformApply = await loadWorkflow(terraformApplyPath);
+const uiValidate = await loadWorkflow(uiValidatePath);
 const automaticOn = automatic.workflow.on;
 const productionOn = production.workflow.on;
 const terraformPrOn = terraformPr.workflow.on;
 const terraformApplyOn = terraformApply.workflow.on;
+const uiValidateOn = uiValidate.workflow.on;
 
 expect(Boolean(automaticOn?.push), "automatic workflow must run on push");
 expect(!automaticOn?.workflow_dispatch, "automatic workflow must not expose workflow_dispatch");
@@ -259,7 +262,17 @@ expect(
   terraformPr.workflow.jobs?.gate?.name === "Terraform Gate",
   "Terraform aggregate gate must retain its stable name"
 );
+expect(
+  terraformPr.workflow.jobs?.validate?.name === "Terraform Validate",
+  "Terraform credential-free validation must have a unique stable check name"
+);
 const terraformValidate = JSON.stringify(terraformPr.workflow.jobs?.validate ?? {});
+expect(
+  terraformPr.workflow.jobs?.validate?.steps?.some(
+    (step) => step?.run === "pnpm run test:delivery-policy"
+  ),
+  "Terraform validation must gate on the parsed delivery workflow validator"
+);
 expect(
   !/id-token|google-github-actions\/auth|secrets\./.test(terraformValidate),
   "Terraform validation job must remain credential-free"
@@ -314,6 +327,26 @@ expect(
     terraformApply.source
   ),
   "Terraform apply must not consume PR artifacts or require a second manual gate"
+);
+
+expect(Boolean(uiValidateOn?.pull_request), "UI validation must run on pull requests");
+expect(
+  uiValidateOn?.pull_request?.paths === undefined,
+  "UI validation must not use pull-request path filters"
+);
+expect(
+  uiValidate.workflow.jobs?.validate?.name === "UI Validate",
+  "UI validation must have a unique stable check name"
+);
+expect(
+  uiValidate.workflow.jobs?.validate?.name !== terraformPr.workflow.jobs?.validate?.name,
+  "UI and Terraform validation check names must remain distinct"
+);
+expect(
+  uiValidate.workflow.jobs?.validate?.steps?.some(
+    (step) => step?.run === "pnpm run test:delivery-policy"
+  ),
+  "UI validation must gate on the parsed delivery workflow validator"
 );
 
 if (failures.length > 0) {


### PR DESCRIPTION
## What changed

- grants `roles/iam.roleAdmin` only to the dedicated Terraform apply service account
- lets the automatic main apply refresh and manage the repository-owned custom bucket-policy reader role
- hardens policy checks so the role must live in the exact apply-role set and cannot be relocated to planner, publisher, dev, or production identities
- adds hostile missing, additive, and relocation fixtures

## Why

The first automatic post-merge apply failed closed before creating its plan because the applier lacked `iam.roles.get`. No Terraform apply occurred and the legacy identity remains intact.

## Verification

- full `pnpm run validate` passed
- independent security review passed after replaying the relocation bypass
- a create-only bootstrap installed exactly this one grant
- current expected authenticated PR plan: 0 add, 0 change, 12 destroy (legacy shared identity only)

## Safety

- `DEV_DEPLOY_ENABLED` remains unset
- no production application deployment is triggered