### PR TITLE
Allow deployers to inspect site buckets

### DIFF
--- a/infra/terraform/README.md
+++ b/infra/terraform/README.md
@@ -64,6 +64,12 @@ uses resource-level `roles/run.developer` and preserves service IAM. A trusted a
 separately grant `allUsers` `roles/run.invoker` for an intended public service. Both PR and apply
 pass `manage_deployment_service_iam=true` so they plan with identical, verified service-IAM inputs.
 
+Static-site deployers receive `roles/storage.objectAdmin` only on their own environment bucket.
+Because `gcloud storage rsync` also reads bucket metadata, each receives bucket-scoped
+`roles/storage.legacyBucketReader` on that same bucket. That predefined role includes
+`storage.buckets.get` plus list/read-metadata permissions and no bucket-IAM or object write/delete
+permissions. Dev has no production-bucket grant; production has no dev-bucket grant.
+
 ## Credential-free validation
 
 Run from this directory:

--- a/infra/terraform/check-policy.sh
+++ b/infra/terraform/check-policy.sh
@@ -406,6 +406,75 @@ for identity in dev prod; do
   contains_fixed "member     = \"serviceAccount:\${google_service_account.${identity}.email}\"" <(printf '%s\n' "$block")
 done
 
+assert_deployer_bucket_binding() {
+  local resource_name="$1"
+  local expected_bucket="$2"
+  local expected_role="$3"
+  local identity="$4"
+  local block
+
+  block="$(awk -v resource_name="$resource_name" '
+    $0 == "resource \"google_storage_bucket_iam_member\" \"" resource_name "\" {" { capture = 1 }
+    capture { print }
+    /^}/ && capture { exit }
+  ' "$root/infra/terraform/cloud-run.tf")"
+  contains_fixed "bucket = $expected_bucket" <(printf '%s\n' "$block")
+  contains_fixed "role   = \"$expected_role\"" <(printf '%s\n' "$block")
+  contains_fixed "member = \"serviceAccount:\${google_service_account.${identity}.email}\"" <(printf '%s\n' "$block")
+}
+
+assert_deployer_bucket_binding dev_deployer google_storage_bucket.site_dev.name roles/storage.objectAdmin dev
+assert_deployer_bucket_binding prod_deployer google_storage_bucket.site.name roles/storage.objectAdmin prod
+assert_deployer_bucket_binding dev_bucket_metadata_reader google_storage_bucket.site_dev.name roles/storage.legacyBucketReader dev
+assert_deployer_bucket_binding prod_bucket_metadata_reader google_storage_bucket.site.name roles/storage.legacyBucketReader prod
+
+deployer_iam_inventory="$(awk '
+  function brace_delta(line, copy, opens, closes) {
+    copy = line
+    opens = gsub(/{/, "{", copy)
+    copy = line
+    closes = gsub(/}/, "}", copy)
+    return opens - closes
+  }
+  function finish_block() {
+    if (block ~ /google_service_account\.(dev|prod)\.email/) print header
+    capture = 0
+    depth = 0
+    header = ""
+    block = ""
+  }
+  /^resource "/ {
+    if (capture) finish_block()
+    capture = 1
+    header = $0
+    block = $0 ORS
+    depth = brace_delta($0)
+    if (depth == 0) finish_block()
+    next
+  }
+  capture {
+    block = block $0 ORS
+    depth += brace_delta($0)
+    if (depth == 0) finish_block()
+  }
+  END { if (capture) finish_block() }
+' "$root/infra/terraform"/*.tf | LC_ALL=C sort)"
+expected_deployer_iam_inventory='resource "google_artifact_registry_repository_iam_member" "dev_reader" {
+resource "google_artifact_registry_repository_iam_member" "prod_reader" {
+resource "google_cloud_run_v2_service_iam_member" "dev_deployer" {
+resource "google_cloud_run_v2_service_iam_member" "prod_deployer" {
+resource "google_service_account_iam_member" "dev_act_as_run" {
+resource "google_service_account_iam_member" "prod_act_as_run" {
+resource "google_storage_bucket_iam_member" "dev_bucket_metadata_reader" {
+resource "google_storage_bucket_iam_member" "dev_deployer" {
+resource "google_storage_bucket_iam_member" "prod_bucket_metadata_reader" {
+resource "google_storage_bucket_iam_member" "prod_deployer" {'
+if [ "$deployer_iam_inventory" != "$expected_deployer_iam_inventory" ]; then
+  echo "Dev/prod IAM inventory differs from the exact environment-scoped allowlist." >&2
+  printf 'Observed deployer IAM resources:\n%s\n' "$deployer_iam_inventory" >&2
+  exit 1
+fi
+
 if awk '
   /^resource / { capture = 1; block = $0 ORS; header = $0; next }
   capture { block = block $0 ORS }

--- a/infra/terraform/cloud-run.tf
+++ b/infra/terraform/cloud-run.tf
@@ -148,6 +148,20 @@ resource "google_storage_bucket_iam_member" "prod_deployer" {
   member = "serviceAccount:${google_service_account.prod.email}"
 }
 
+# gcloud storage rsync reads bucket metadata after synchronizing objects.
+# Legacy Bucket Reader is bucket-scoped and contains no write permissions.
+resource "google_storage_bucket_iam_member" "dev_bucket_metadata_reader" {
+  bucket = google_storage_bucket.site_dev.name
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.dev.email}"
+}
+
+resource "google_storage_bucket_iam_member" "prod_bucket_metadata_reader" {
+  bucket = google_storage_bucket.site.name
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.prod.email}"
+}
+
 # Cloud Run service-level grants are disabled by default so a trust bootstrap
 # does not require the application services to exist. Enable only after an
 # administrator verifies the named services and reviews the state-backed plan.

--- a/infra/terraform/test-check-policy.sh
+++ b/infra/terraform/test-check-policy.sh
@@ -80,5 +80,9 @@ expect_policy_failure implicit-service-iam \
   "sed -i.bak 's/manage_deployment_service_iam=true/manage_deployment_service_iam=false/g' \"\$1/.github/workflows/terraform-pr.yml\""
 expect_policy_failure terraform-job-name-shadowed-by-step \
   "sed -i.bak 's/^    name: Terraform Validate$/    name: UI Validate/' \"\$1/.github/workflows/terraform-pr.yml\""
+expect_policy_failure deployer-bucket-metadata-writer \
+  "sed -i.bak 's/roles\/storage.legacyBucketReader/roles\/storage.legacyBucketOwner/g' \"\$1/infra/terraform/cloud-run.tf\""
+expect_policy_failure additive-deployer-storage-role \
+  "printf '\nresource \"google_storage_bucket_iam_member\" \"rogue_dev_bucket_reader\" {\n  bucket = google_storage_bucket.site.name\n  role = \"roles/storage.objectViewer\"\n  member = \"serviceAccount:\${google_service_account.dev.email}\"\n}\n' >> \"\$1/infra/terraform/services.tf\""
 
 echo "Terraform policy search portability tests passed."


### PR DESCRIPTION
## What changed

- grants bucket-scoped `roles/storage.legacyBucketReader` to the dev deployer on the dev site bucket
- grants the same metadata-only role to the production deployer on the production site bucket
- adds exact environment IAM inventories and hostile cross-environment/additive-role fixtures

## Why

The dev site upload wrote objects successfully, then the final `gcloud storage rsync --delete-unmatched-destination-objects` failed because the dev deployer lacked `storage.buckets.get`. Functions deployed and smoke-tested successfully; production was untouched.

## Expected Terraform plan

`add=2 change=0 destroy=0` for the two exact bucket metadata-reader bindings.

## Security

`roles/storage.legacyBucketReader` includes bucket metadata and list permissions only; it has no bucket IAM mutation or object create/update/delete/content-read permissions. Independent security review passed.

## Verification

- full `pnpm run validate` passed
- Terraform fmt/init/validate and policy suites passed
- local authenticated plan shows exactly the two intended creates
- dev site currently still responds 200 after the partial upload
- no production application deployment is triggered