### PR TITLE
Make discovery E2E checks environment-aware

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -333,6 +333,7 @@ jobs:
         working-directory: site
         env:
           PLAYWRIGHT_TEST_BASE_URL: https://dev.briananderson.xyz
+          PUBLIC_SITE_URL: https://dev.briananderson.xyz
         run: pnpm run test:e2e
       - name: Run dev API smoke checks
         if: steps.config.outputs.ready == 'true'

--- a/site/e2e/public-surfaces.spec.ts
+++ b/site/e2e/public-surfaces.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "@playwright/test";
 
+const expectedSiteOrigin = new URL(process.env.PUBLIC_SITE_URL || "https://briananderson.xyz")
+  .origin;
+
 const publicSurfaces = [
   { path: "/proof/", heading: "./proof-ledger" },
   { path: "/ai-evals/", heading: "./ai-evals" },
@@ -33,9 +36,9 @@ test.describe("public evidence surfaces", () => {
     const llmsFull = await (await request.get("/llms-full.txt")).text();
 
     for (const surface of publicSurfaces) {
-      expect(sitemap).toContain(`https://briananderson.xyz${surface.path}`);
-      expect(llms).toContain(`https://briananderson.xyz${surface.path}`);
-      expect(llmsFull).toContain(`https://briananderson.xyz${surface.path}`);
+      expect(sitemap).toContain(`${expectedSiteOrigin}${surface.path}`);
+      expect(llms).toContain(`${expectedSiteOrigin}${surface.path}`);
+      expect(llmsFull).toContain(`${expectedSiteOrigin}${surface.path}`);
     }
   });
 

--- a/site/scripts/validate-delivery-workflows.mjs
+++ b/site/scripts/validate-delivery-workflows.mjs
@@ -80,6 +80,19 @@ for (const jobName of ["publish-functions", "deploy-functions-dev", "deploy-site
   );
 }
 
+const devE2eStep = automatic.workflow.jobs?.["deploy-site-dev"]?.steps?.find(
+  (step) => step?.name === "Run dev end-to-end checks"
+);
+expect(Boolean(devE2eStep), "dev static deployment must retain its end-to-end gate");
+expect(
+  devE2eStep?.env?.PLAYWRIGHT_TEST_BASE_URL === "https://dev.briananderson.xyz",
+  "dev E2E browser requests must target the dev site"
+);
+expect(
+  devE2eStep?.env?.PUBLIC_SITE_URL === "https://dev.briananderson.xyz",
+  "dev E2E machine-readable expectations must use the dev public origin"
+);
+
 expect(
   automatic.workflow.jobs?.["publish-functions"]?.environment === undefined,
   "publisher identity must remain scoped to the exact main-ref subject, not an environment subject"


### PR DESCRIPTION
## What changed

- derives machine-readable discovery URL expectations from `PUBLIC_SITE_URL`
- defaults safely to the production origin for local and ordinary CI runs
- sets the exact dev origin in the post-deploy E2E environment
- policy-locks `PUBLIC_SITE_URL` and `PLAYWRIGHT_TEST_BASE_URL` to the same dev origin

## Root cause

The dev deployment generated the correct dev sitemap, but the E2E spec hardcoded the production hostname. The post-deploy run therefore failed after upload/verification despite receiving correct dev URLs.

## Verification

- exact CI-mode dev regression command passed
- production-default focused case passed
- live dev public-surfaces spec passed 6/6
- full `pnpm run validate` passed
- independent security review passed

## Deployment boundary

Dev is enabled and will redeploy this reviewed merge. Production application deployment remains manual and is not dispatched.