### PR TITLE
Use Node 24 Terraform setup action

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -49,7 +49,7 @@ jobs:
           service_account: ${{ secrets.GCP_WIF_APPLY_SA_EMAIL }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
 

--- a/.github/workflows/terraform-pr.yml
+++ b/.github/workflows/terraform-pr.yml
@@ -84,7 +84,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
 
@@ -128,7 +128,7 @@ jobs:
           service_account: ${{ secrets.GCP_WIF_PLAN_SA_EMAIL }}
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
         with:
           terraform_version: 1.15.8
 

--- a/infra/terraform/test-check-policy.sh
+++ b/infra/terraform/test-check-policy.sh
@@ -3,10 +3,12 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 policy="$root/infra/terraform/check-policy.sh"
+workflow_policy="$root/site/scripts/validate-workflow-policy.mjs"
 standard_path="/usr/bin:/bin"
 
 # Exercise the preferred search implementation when ripgrep is installed.
 "$policy"
+node "$workflow_policy"
 "$root/infra/terraform/test-sanitize-plan-evidence.sh"
 
 # GitHub's Ubuntu runner does not guarantee ripgrep, so exercise the grep fallback too.
@@ -51,6 +53,30 @@ expect_policy_failure() {
     exit 1
   fi
 }
+
+expect_workflow_policy_failure() {
+  local label="$1"
+  local mutation="$2"
+  local fixture="$test_dir/$label"
+
+  mkdir -p "$fixture/.github"
+  cp -R "$root/.github/workflows" "$fixture/.github/workflows"
+  sh -c "$mutation" sh "$fixture"
+
+  set +e
+  node "$workflow_policy" "$fixture/.github/workflows" >"$fixture/stdout" 2>"$fixture/stderr"
+  local status=$?
+  set -e
+  if [ "$status" -eq 0 ]; then
+    echo "Expected workflow-policy fixture '$label' to fail closed." >&2
+    exit 1
+  fi
+}
+
+expect_workflow_policy_failure stale-setup-terraform-pin \
+  "sed -i.bak 's/dfe3c3f87815947d99a8997f908cb6525fc44e9e/b9cd54a3c349d3f38e8881555d616ced269862dd/g' \"\$1/.github/workflows/terraform-pr.yml\""
+expect_workflow_policy_failure floating-setup-terraform-tag \
+  "sed -i.bak 's/dfe3c3f87815947d99a8997f908cb6525fc44e9e/v4/g' \"\$1/.github/workflows/terraform-pr.yml\""
 
 expect_policy_failure state-write-role \
   "sed -i.bak 's/role   = \"roles\/storage.objectViewer\"/role   = \"roles\/storage.objectAdmin\"/' \"\$1/infra/terraform/main.tf\""

--- a/site/scripts/validate-workflow-policy.mjs
+++ b/site/scripts/validate-workflow-policy.mjs
@@ -12,6 +12,9 @@ const shaPattern = /^[0-9a-f]{40}$/;
 const versionCommentPattern = /^v\d+(?:\.\d+){0,2}$/;
 const pnpmVersion = "10.33.0";
 const nodeMajor = "22";
+const setupTerraformAction = "hashicorp/setup-terraform";
+const setupTerraformSha = "dfe3c3f87815947d99a8997f908cb6525fc44e9e";
+const expectedSetupTerraformCount = 3;
 
 const workflowFiles = (await readdir(workflowsRoot)).filter((file) => /\.ya?ml$/.test(file)).sort();
 
@@ -19,6 +22,7 @@ const failures = [];
 let externalActionCount = 0;
 let nodeVersionCount = 0;
 let pnpmSetupCount = 0;
+const setupTerraformRefs = [];
 
 for (const file of workflowFiles) {
   const path = join(workflowsRoot, file);
@@ -51,6 +55,10 @@ for (const file of workflowFiles) {
       }
 
       for (const step of job?.steps ?? []) {
+        const action = String(step?.uses ?? "");
+        if (action.startsWith(`${setupTerraformAction}@`)) {
+          setupTerraformRefs.push({ file, jobName, ref: action.slice(action.lastIndexOf("@") + 1) });
+        }
         if (String(step?.uses ?? "").startsWith("pnpm/action-setup@")) {
           pnpmSetupCount += 1;
           if (String(step?.with?.version ?? "") !== pnpmVersion) {
@@ -110,6 +118,18 @@ for (const file of workflowFiles) {
 if (externalActionCount === 0) failures.push("no external GitHub Actions were inspected");
 if (nodeVersionCount === 0) failures.push("no node-version declarations were inspected");
 if (pnpmSetupCount === 0) failures.push("no pnpm/action-setup declarations were inspected");
+if (setupTerraformRefs.length !== expectedSetupTerraformCount) {
+  failures.push(
+    `${setupTerraformAction} must appear exactly ${expectedSetupTerraformCount} times, found ${setupTerraformRefs.length}`
+  );
+}
+for (const { file, jobName, ref } of setupTerraformRefs) {
+  if (ref !== setupTerraformSha) {
+    failures.push(
+      `${file}: job ${jobName} must pin ${setupTerraformAction} to ${setupTerraformSha}, found ${ref}`
+    );
+  }
+}
 
 const siteManifest = JSON.parse(await readFile(join(siteRoot, "package.json"), "utf8"));
 const functionsRoot = join(siteRoot, "functions");


### PR DESCRIPTION
## What changed
- pin all three hashicorp/setup-terraform uses to v4.0.1 at immutable commit dfe3c3f87815947d99a8997f908cb6525fc44e9e
- require exactly three references using the approved SHA
- add hostile regressions for the previous Node 20 SHA and a floating v4 tag

## Why
GitHub was forcing the prior Node 20 action onto Node 24 and warning about the deprecated runtime. v4.0.1 declares node24 and fixes its Node 24 deprecation warning.

## Validation
- full site validation
- workflow and delivery policy tests
- Terraform policy hostile tests
- isolated credential-free Terraform init/validate
- independent code and security review

No deploy enablement, triggers, credentials, WIF identities, environments, Terraform authorization, or production behavior changed.