### PR TITLE
Keep Terraform policy checks dependency-free

### DIFF
--- a/infra/terraform/check-policy.sh
+++ b/infra/terraform/check-policy.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 workflows="$root/.github/workflows"
+setup_terraform_action="hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e"
+setup_terraform_declaration="$setup_terraform_action # v4"
 legacy_import="import""-resources.sh"
 legacy_identity="github""-ci-deployer"
 legacy_writer="google_project_iam_member.ci_""artifact_writer"
@@ -555,6 +557,26 @@ ui_validate_block="$(awk '
 ' "$workflows/validate-ui.yml")"
 contains_fixed '    name: UI Validate' <(printf '%s\n' "$ui_validate_block")
 contains_fixed 'pnpm run test:delivery-policy' <(printf '%s\n' "$ui_validate_block")
+
+setup_terraform_refs="$(awk '
+  /^        uses:[[:space:]]*hashicorp\/setup-terraform@/ ||
+  /^      - uses:[[:space:]]*hashicorp\/setup-terraform@/ {
+    line = $0
+    sub(/^        uses:[[:space:]]*/, "", line)
+    sub(/^      - uses:[[:space:]]*/, "", line)
+    print line
+  }
+' "$workflows/terraform-pr.yml" "$workflows/terraform-apply.yml")"
+setup_terraform_count="$(printf '%s\n' "$setup_terraform_refs" | awk 'NF { count += 1 } END { print count + 0 }')"
+if [ "$setup_terraform_count" -ne 3 ]; then
+  echo "Terraform workflows must contain exactly 3 executable setup-terraform uses; found $setup_terraform_count." >&2
+  exit 1
+fi
+if printf '%s\n' "$setup_terraform_refs" | grep -Fvx -- "$setup_terraform_declaration" >/dev/null; then
+  echo "Every setup-terraform use must pin $setup_terraform_action with the readable # v4 comment." >&2
+  exit 1
+fi
+
 contains_fixed '-lock=false' "$workflows/terraform-pr.yml"
 contains_fixed '-var="manage_deployment_service_iam=true"' "$workflows/terraform-pr.yml"
 contains_fixed '-var="manage_deployment_service_iam=true"' "$workflows/terraform-apply.yml"

--- a/infra/terraform/test-check-policy.sh
+++ b/infra/terraform/test-check-policy.sh
@@ -3,12 +3,10 @@ set -euo pipefail
 
 root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 policy="$root/infra/terraform/check-policy.sh"
-workflow_policy="$root/site/scripts/validate-workflow-policy.mjs"
 standard_path="/usr/bin:/bin"
 
 # Exercise the preferred search implementation when ripgrep is installed.
 "$policy"
-node "$workflow_policy"
 "$root/infra/terraform/test-sanitize-plan-evidence.sh"
 
 # GitHub's Ubuntu runner does not guarantee ripgrep, so exercise the grep fallback too.
@@ -54,29 +52,16 @@ expect_policy_failure() {
   fi
 }
 
-expect_workflow_policy_failure() {
-  local label="$1"
-  local mutation="$2"
-  local fixture="$test_dir/$label"
-
-  mkdir -p "$fixture/.github"
-  cp -R "$root/.github/workflows" "$fixture/.github/workflows"
-  sh -c "$mutation" sh "$fixture"
-
-  set +e
-  node "$workflow_policy" "$fixture/.github/workflows" >"$fixture/stdout" 2>"$fixture/stderr"
-  local status=$?
-  set -e
-  if [ "$status" -eq 0 ]; then
-    echo "Expected workflow-policy fixture '$label' to fail closed." >&2
-    exit 1
-  fi
-}
-
-expect_workflow_policy_failure stale-setup-terraform-pin \
+expect_policy_failure stale-setup-terraform-pin \
   "sed -i.bak 's/dfe3c3f87815947d99a8997f908cb6525fc44e9e/b9cd54a3c349d3f38e8881555d616ced269862dd/g' \"\$1/.github/workflows/terraform-pr.yml\""
-expect_workflow_policy_failure floating-setup-terraform-tag \
+expect_policy_failure floating-setup-terraform-tag \
   "sed -i.bak 's/dfe3c3f87815947d99a8997f908cb6525fc44e9e/v4/g' \"\$1/.github/workflows/terraform-pr.yml\""
+expect_policy_failure missing-setup-terraform-use \
+  "sed -i.bak 's/uses: hashicorp\/setup-terraform@/run: echo removed-setup-terraform@/g' \"\$1/.github/workflows/terraform-pr.yml\""
+expect_policy_failure extra-setup-terraform-use \
+  "printf '\n      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4\n' >> \"\$1/.github/workflows/terraform-pr.yml\""
+expect_policy_failure inert-run-block-setup-terraform-use \
+  "sed -i.bak 's/        uses: hashicorp\/setup-terraform@/        run: echo removed-setup-terraform@/' \"\$1/.github/workflows/terraform-apply.yml\"; printf '\n      - name: Inert setup text\n        run: |\n          uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4\n' >> \"\$1/.github/workflows/terraform-apply.yml\""
 
 expect_policy_failure state-write-role \
   "sed -i.bak 's/role   = \"roles\/storage.objectViewer\"/role   = \"roles\/storage.objectAdmin\"/' \"\$1/infra/terraform/main.tf\""


### PR DESCRIPTION
## What changed
- enforce the exact setup-terraform action count, immutable SHA, and v4 comment directly in the dependency-free Terraform shell policy
- keep the parsed YAML policy in UI validation
- add hostile stale, floating, missing, extra, and inert run-block decoy cases

## Root cause
The first Node 24 action PR made the Terraform policy harness invoke the site YAML validator. The main apply job intentionally does not install site dependencies, so validation failed on missing js-yaml before plan/apply.

## Validation
- full repository validation
- dependency-absent shell policy suite
- hostile policy fixtures including inert YAML block decoy
- Terraform fmt/init/validate
- independent review and verification

No workflow triggers, credentials, WIF identities, environments, deploy flags, authorization, or production behavior changed.